### PR TITLE
fix: reorganize endpoints

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1,50 +1,11 @@
 import express from 'express';
-import { rpcError, rpcSuccess, storageEngine } from './helpers/utils';
 import log from './helpers/log';
-import { queues } from './lib/queue';
+import { rpcError, storageEngine } from './helpers/utils';
 import getModerationList from './lib/moderationList';
-import { name, version } from '../package.json';
 import VotesReport from './lib/votesReport';
+import { queues } from './lib/queue';
 
 const router = express.Router();
-
-router.get('/', (req, res) => {
-  const commit = process.env.COMMIT_HASH || '';
-  const v = commit ? `${version}#${commit.substr(0, 7)}` : version;
-  return res.json({
-    name,
-    version: v
-  });
-});
-
-router.post('/votes/generate', async (req, res) => {
-  log.info(`[http] POST /votes/generate`);
-
-  const body = req.body || {};
-  const event = body.event.toString();
-  const id = body.id.toString().replace('proposal/', '');
-
-  if (req.headers['authenticate'] !== process.env.WEBHOOK_AUTH_TOKEN?.toString()) {
-    return rpcError(res, 'UNAUTHORIZED', id);
-  }
-
-  if (!event || !id) {
-    return rpcError(res, 'Invalid Request', id);
-  }
-
-  if (event !== 'proposal/end') {
-    return rpcSuccess(res, 'Event skipped', id);
-  }
-
-  try {
-    await new VotesReport(id, storageEngine(process.env.VOTE_REPORT_SUBDIR)).canBeCached();
-    queues.add(id);
-    return rpcSuccess(res, 'Cache file generation queued', id);
-  } catch (e) {
-    log.error(e);
-    return rpcError(res, 'INTERNAL_ERROR', id);
-  }
-});
 
 router.post('/votes/:id', async (req, res) => {
   const { id } = req.params;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import express from 'express';
 import compression from 'compression';
 import cors from 'cors';
 import api from './api';
+import webhook from './webhook';
 import log from './helpers/log';
 import './lib/queue';
 import { name, version } from '../package.json';
@@ -14,6 +15,7 @@ app.use(express.json({ limit: '4mb' }));
 app.use(cors({ maxAge: 86400 }));
 app.use(compression());
 app.use('/api', api);
+app.use('/', webhook);
 
 app.get('/', (req, res) => {
   const commit = process.env.COMMIT_HASH || '';

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import cors from 'cors';
 import api from './api';
 import log from './helpers/log';
 import './lib/queue';
+import { name, version } from '../package.json';
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -12,6 +13,15 @@ const PORT = process.env.PORT || 3000;
 app.use(express.json({ limit: '4mb' }));
 app.use(cors({ maxAge: 86400 }));
 app.use(compression());
-app.use('/', api);
+app.use('/api', api);
+
+app.get('/', (req, res) => {
+  const commit = process.env.COMMIT_HASH || '';
+  const v = commit ? `${version}#${commit.substr(0, 7)}` : version;
+  return res.json({
+    name,
+    version: v
+  });
+});
 
 app.listen(PORT, () => log.info(`[http] Start server at http://localhost:${PORT}`));

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ app.use('/api', api);
 
 app.get('/', (req, res) => {
   const commit = process.env.COMMIT_HASH || '';
-  const v = commit ? `${version}#${commit.substr(0, 7)}` : version;
+  const v = commit ? `${version}#${commit.substring(0, 7)}` : version;
   return res.json({
     name,
     version: v

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -7,7 +7,7 @@ import { queues } from './lib/queue';
 const router = express.Router();
 
 router.post('/webhook', async (req, res) => {
-  log.info(`[http] POST /votes/generate`);
+  log.info(`[http] POST /webhook`);
 
   const body = req.body || {};
   const event = body.event.toString();

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -1,0 +1,38 @@
+import express from 'express';
+import log from './helpers/log';
+import { rpcError, rpcSuccess, storageEngine } from './helpers/utils';
+import VotesReport from './lib/votesReport';
+import { queues } from './lib/queue';
+
+const router = express.Router();
+
+router.post('/webhook', async (req, res) => {
+  log.info(`[http] POST /votes/generate`);
+
+  const body = req.body || {};
+  const event = body.event.toString();
+  const id = body.id.toString().replace('proposal/', '');
+
+  if (req.headers['authenticate'] !== process.env.WEBHOOK_AUTH_TOKEN?.toString()) {
+    return rpcError(res, 'UNAUTHORIZED', id);
+  }
+
+  if (!event || !id) {
+    return rpcError(res, 'Invalid Request', id);
+  }
+
+  if (event !== 'proposal/end') {
+    return rpcSuccess(res, 'Event skipped', id);
+  }
+
+  try {
+    await new VotesReport(id, storageEngine(process.env.VOTE_REPORT_SUBDIR)).canBeCached();
+    queues.add(id);
+    return rpcSuccess(res, 'Cache file generation queued', id);
+  } catch (e) {
+    log.error(e);
+    return rpcError(res, 'INTERNAL_ERROR', id);
+  }
+});
+
+export default router;

--- a/test/e2e/__snapshots__/moderationList.test.ts.snap
+++ b/test/e2e/__snapshots__/moderationList.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`GET /moderationList ignores invalid field, and returns only verifiedSpaces 1`] = `
+exports[`GET /api/moderationList ignores invalid field, and returns only verifiedSpaces 1`] = `
 {
   "verifiedSpaces": {
     "space1.eth": 1,
@@ -9,7 +9,7 @@ exports[`GET /moderationList ignores invalid field, and returns only verifiedSpa
 }
 `;
 
-exports[`GET /moderationList returns multiple list: verifiedSpaces,flaggedProposals 1`] = `
+exports[`GET /api/moderationList returns multiple list: verifiedSpaces,flaggedProposals 1`] = `
 {
   "flaggedProposals": [
     "0x1",
@@ -22,7 +22,7 @@ exports[`GET /moderationList returns multiple list: verifiedSpaces,flaggedPropos
 }
 `;
 
-exports[`GET /moderationList when fields params is empty returns all the list 1`] = `
+exports[`GET /api/moderationList when fields params is empty returns all the list 1`] = `
 {
   "flaggedLinks": [
     "https://gogle.com",
@@ -39,7 +39,7 @@ exports[`GET /moderationList when fields params is empty returns all the list 1`
 }
 `;
 
-exports[`GET /moderationList when fields params is set returns only the selected flaggedLinks list 1`] = `
+exports[`GET /api/moderationList when fields params is set returns only the selected flaggedLinks list 1`] = `
 {
   "flaggedLinks": [
     "https://gogle.com",
@@ -48,7 +48,7 @@ exports[`GET /moderationList when fields params is set returns only the selected
 }
 `;
 
-exports[`GET /moderationList when fields params is set returns only the selected flaggedProposals list 1`] = `
+exports[`GET /api/moderationList when fields params is set returns only the selected flaggedProposals list 1`] = `
 {
   "flaggedProposals": [
     "0x1",
@@ -57,7 +57,7 @@ exports[`GET /moderationList when fields params is set returns only the selected
 }
 `;
 
-exports[`GET /moderationList when fields params is set returns only the selected verifiedSpaces list 1`] = `
+exports[`GET /api/moderationList when fields params is set returns only the selected verifiedSpaces list 1`] = `
 {
   "verifiedSpaces": {
     "space1.eth": 1,

--- a/test/e2e/moderationList.test.ts
+++ b/test/e2e/moderationList.test.ts
@@ -2,10 +2,10 @@ import request from 'supertest';
 
 const HOST = `http://localhost:${process.env.PORT || 3000}`;
 
-describe('GET /moderationList', () => {
+describe('GET /api/moderationList', () => {
   describe('when fields params is empty', () => {
     it('returns all the list', async () => {
-      const response = await request(HOST).get('/moderationList');
+      const response = await request(HOST).get('/api/moderationList');
 
       expect(response.statusCode).toBe(200);
       expect(response.body).toMatchSnapshot();
@@ -16,7 +16,7 @@ describe('GET /moderationList', () => {
     it.each(['flaggedLinks', 'verifiedSpaces', 'flaggedProposals'])(
       'returns only the selected %s list',
       async field => {
-        const response = await request(HOST).get(`/moderationList?fields=${field}`);
+        const response = await request(HOST).get(`/api/moderationList?fields=${field}`);
 
         expect(response.statusCode).toBe(200);
         expect(response.body).toMatchSnapshot();
@@ -26,7 +26,7 @@ describe('GET /moderationList', () => {
 
   it('returns multiple list: verifiedSpaces,flaggedProposals', async () => {
     const response = await request(HOST).get(
-      `/moderationList?fields=verifiedSpaces,flaggedProposals`
+      `/api/moderationList?fields=verifiedSpaces,flaggedProposals`
     );
 
     expect(response.statusCode).toBe(200);
@@ -34,7 +34,9 @@ describe('GET /moderationList', () => {
   });
 
   it('ignores invalid field, and returns only verifiedSpaces', async () => {
-    const response = await request(HOST).get(`/moderationList?fields=verifiedSpaces,testInvalid`);
+    const response = await request(HOST).get(
+      `/api/moderationList?fields=verifiedSpaces,testInvalid`
+    );
 
     expect(response.statusCode).toBe(200);
     expect(response.body).toMatchSnapshot();


### PR DESCRIPTION
Reorganize API endpoints, for a consistent naming and path for all endpoints.

This service is getting more and more diverse features:
- #5 
- #9 
- #12 
- #15 

Reorganizing now to lay the ground

The /webhook has been isolated, as it'll be shared by all other futures update.