### PR TITLE
fix: rename /moderationList to /moderation

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,15 +107,16 @@ Return a curated list of moderated data.
 Send a `GET` request
 
 ```bash
-curl localhost:3000/api/moderationList
+curl localhost:3000/api/moderation
 ```
 
-You can also choose to filter the list, with the `?fields=` query params.
+You can also choose to filter the list, with the `?list=` query params.
 Valid values are:
 
 - `flaggedProposals`
 - `flaggedLinks`
 - `verifiedSpaces`
+- `flaggedSpaces`
 
 You can pass multiple list, separated by a comma.
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -36,11 +36,11 @@ router.post('/votes/:id', async (req, res) => {
   }
 });
 
-router.get('/moderationList', async (req, res) => {
-  const { fields } = req.query;
+router.get('/moderation', async (req, res) => {
+  const { list } = req.query;
 
   try {
-    res.json(getModerationList(fields ? (fields as string).split(',') : undefined));
+    res.json(getModerationList(list ? (list as string).split(',') : undefined));
   } catch (e) {
     log.error(e);
     return rpcError(res, 'INTERNAL_ERROR', '');

--- a/test/e2e/__snapshots__/moderation.test.ts.snap
+++ b/test/e2e/__snapshots__/moderation.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`GET /api/moderationList ignores invalid field, and returns only verifiedSpaces 1`] = `
+exports[`GET /api/moderation ignores invalid field, and returns only verifiedSpaces 1`] = `
 {
   "verifiedSpaces": [
     "space1.eth",
@@ -9,7 +9,7 @@ exports[`GET /api/moderationList ignores invalid field, and returns only verifie
 }
 `;
 
-exports[`GET /api/moderationList returns multiple list: verifiedSpaces,flaggedProposals 1`] = `
+exports[`GET /api/moderation returns multiple list: verifiedSpaces,flaggedProposals 1`] = `
 {
   "flaggedProposals": [
     "0x1",
@@ -22,7 +22,7 @@ exports[`GET /api/moderationList returns multiple list: verifiedSpaces,flaggedPr
 }
 `;
 
-exports[`GET /api/moderationList when fields params is empty returns all the list 1`] = `
+exports[`GET /api/moderation when list params is empty returns all the list 1`] = `
 {
   "flaggedLinks": [
     "https://gogle.com",
@@ -43,7 +43,7 @@ exports[`GET /api/moderationList when fields params is empty returns all the lis
 }
 `;
 
-exports[`GET /api/moderationList when fields params is set returns only the selected flaggedLinks list 1`] = `
+exports[`GET /api/moderation when list params is set returns only the selected flaggedLinks list 1`] = `
 {
   "flaggedLinks": [
     "https://gogle.com",
@@ -52,7 +52,7 @@ exports[`GET /api/moderationList when fields params is set returns only the sele
 }
 `;
 
-exports[`GET /api/moderationList when fields params is set returns only the selected flaggedProposals list 1`] = `
+exports[`GET /api/moderation when list params is set returns only the selected flaggedProposals list 1`] = `
 {
   "flaggedProposals": [
     "0x1",
@@ -61,7 +61,7 @@ exports[`GET /api/moderationList when fields params is set returns only the sele
 }
 `;
 
-exports[`GET /api/moderationList when fields params is set returns only the selected verifiedSpaces list 1`] = `
+exports[`GET /api/moderation when list params is set returns only the selected verifiedSpaces list 1`] = `
 {
   "verifiedSpaces": [
     "space1.eth",

--- a/test/e2e/moderation.test.ts
+++ b/test/e2e/moderation.test.ts
@@ -2,21 +2,21 @@ import request from 'supertest';
 
 const HOST = `http://localhost:${process.env.PORT || 3000}`;
 
-describe('GET /api/moderationList', () => {
-  describe('when fields params is empty', () => {
+describe('GET /api/moderation', () => {
+  describe('when list params is empty', () => {
     it('returns all the list', async () => {
-      const response = await request(HOST).get('/api/moderationList');
+      const response = await request(HOST).get('/api/moderation');
 
       expect(response.statusCode).toBe(200);
       expect(response.body).toMatchSnapshot();
     });
   });
 
-  describe('when fields params is set', () => {
+  describe('when list params is set', () => {
     it.each(['flaggedLinks', 'verifiedSpaces', 'flaggedProposals'])(
       'returns only the selected %s list',
       async field => {
-        const response = await request(HOST).get(`/api/moderationList?fields=${field}`);
+        const response = await request(HOST).get(`/api/moderation?list=${field}`);
 
         expect(response.statusCode).toBe(200);
         expect(response.body).toMatchSnapshot();
@@ -26,7 +26,7 @@ describe('GET /api/moderationList', () => {
 
   it('returns multiple list: verifiedSpaces,flaggedProposals', async () => {
     const response = await request(HOST).get(
-      `/api/moderationList?fields=verifiedSpaces,flaggedProposals`
+      `/api/moderation?list=verifiedSpaces,flaggedProposals`
     );
 
     expect(response.statusCode).toBe(200);
@@ -34,9 +34,7 @@ describe('GET /api/moderationList', () => {
   });
 
   it('ignores invalid field, and returns only verifiedSpaces', async () => {
-    const response = await request(HOST).get(
-      `/api/moderationList?fields=verifiedSpaces,testInvalid`
-    );
+    const response = await request(HOST).get(`/api/moderation?list=verifiedSpaces,testInvalid`);
 
     expect(response.statusCode).toBe(200);
     expect(response.body).toMatchSnapshot();


### PR DESCRIPTION
Getting rid of case sensitive routes:

Rename the route /moderationList to /moderation, and ?fields params to be ?list

