### PR TITLE
fix: return signature in r,s,v format

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -53,9 +53,9 @@ router.post('/nft-claimer/:type(space|proposal)/sign', async (req, res) => {
     const { address, id, salt } = req.body;
     switch (req.params.type) {
       case 'space':
-        return res.send(await signSpaceOwner(address, id, salt));
+        return res.json(await signSpaceOwner(address, id, salt));
       case 'proposal':
-        return res.send(await signValidProposal(address, id, salt));
+        return res.json(await signValidProposal(address, id, salt));
       default:
         throw new Error('Invalid Request');
     }

--- a/src/lib/nftClaimer.ts
+++ b/src/lib/nftClaimer.ts
@@ -1,5 +1,6 @@
 import { getAddress } from '@ethersproject/address';
 import { Wallet } from '@ethersproject/wallet';
+import { splitSignature } from '@ethersproject/bytes';
 import snapshot from '@snapshot-labs/snapshot.js';
 import type { TypedDataField } from '@ethersproject/abstract-signer';
 import { fetchProposal, fetchSpace, Space } from '../helpers/snapshot';
@@ -35,7 +36,7 @@ const NETWORK = process.env.NETWORK || '1';
 const signer = new Wallet(process.env.WALLET_PRIVATE_KEY as string);
 
 async function sign(message: Record<string, any>, type: Record<string, Array<TypedDataField>>) {
-  return await signer._signTypedData(domain, type, message);
+  return splitSignature(await signer._signTypedData(domain, type, message));
 }
 
 function mintingAllowed(space: Space) {

--- a/test/e2e/nftClaimer.test.ts
+++ b/test/e2e/nftClaimer.test.ts
@@ -39,8 +39,10 @@ describe('nftClaimer', () => {
         .send({ address, id, salt: '12345' });
 
       expect(response.statusCode).toBe(200);
-      expect(response.headers['content-type']).toMatch(/text\/html/);
-      expect(response.text).toHaveLength(132);
+      expect(response.headers['content-type']).toMatch(/application\/json/);
+      expect(response.body).toHaveProperty('r');
+      expect(response.body).toHaveProperty('s');
+      expect(response.body).toHaveProperty('v');
     });
   });
 
@@ -70,8 +72,10 @@ describe('nftClaimer', () => {
         .send({ address, id, salt });
 
       expect(response.statusCode).toBe(200);
-      expect(response.headers['content-type']).toMatch(/text\/html/);
-      expect(response.text).toHaveLength(132);
+      expect(response.headers['content-type']).toMatch(/application\/json/);
+      expect(response.body).toHaveProperty('r');
+      expect(response.body).toHaveProperty('s');
+      expect(response.body).toHaveProperty('v');
     });
   });
 });


### PR DESCRIPTION
Return signature as a json, with `r`, `s` and `v` keys, instead of string, for easier consumption by smart contract