### PR TITLE
fix: ignore new line characters in reason

### DIFF
--- a/src/lib/votesReport.ts
+++ b/src/lib/votesReport.ts
@@ -118,7 +118,14 @@ class VotesReport {
       choices.push(vote.choice);
     }
 
-    return [vote.voter, choices, vote.vp, vote.created, vote.ipfs, `"${vote.reason}"`]
+    return [
+      vote.voter,
+      choices,
+      vote.vp,
+      vote.created,
+      vote.ipfs,
+      `"${vote.reason.replace(/(\r\n|\n|\r)/gm, '')}"`
+    ]
       .flat()
       .join(',');
   };


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

In the CSV votes report, new line characters in `reason` field are interpreted as is, and it does insert a new line in the CSV file, breaking the CSV format.

## 💊 Fixes / Solution

Fix #46 

New lines should be ignored

## 🚧 Changes

- Add a regex to strip all new lines characters from `reason` field

## 🛠️ Tests

- Go to https://snapshot-lwxw3n2hm-snapshot.vercel.app/#/stgdao.eth/proposal/0x6b703b90d3cd1f82f7c176fc2e566a2bb79e8eb6618a568b52a4f29cb2f8d57b (this votes contains many reason with new lines characters)
- Download the CSV votes report
- There should be no blanks lines in the report