### PR TITLE
fix: fix incorrect webhook auth header

### DIFF
--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -13,7 +13,7 @@ router.post('/webhook', async (req, res) => {
   const event = body.event.toString();
   const id = body.id.toString().replace('proposal/', '');
 
-  if (req.headers['authenticate'] !== process.env.WEBHOOK_AUTH_TOKEN?.toString()) {
+  if (req.headers['Authentication'] !== process.env.WEBHOOK_AUTH_TOKEN?.toString()) {
     return rpcError(res, 'UNAUTHORIZED', id);
   }
 


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

Header keyname for checking the webhook authentication key is incorrect

## 💊 Fixes / Solution

Change the header keyname to the correct one

## 🚧 Changes

- Rename key from `authenticate` to `Authentication`

## 🛠️ Tests

- Nothing