### PR TITLE
fix: fix missing public directory in dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "lint:nofix": "eslint . --ext .ts,.json --ignore-pattern '/dist/*'",
     "lint": "yarn lint:nofix --fix",
-    "build": "tsc -p tsconfig.json && copyfiles data/*.json data/*.txt dist/",
+    "build": "tsc -p tsconfig.json && copyfiles data/*.json data/*.txt public/* dist/",
     "dev": "nodemon src/index.ts -e js,ts",
     "start": "node dist/src/index.js",
     "start:test": "dotenv -e test/.env.test yarn dev",


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

The `public` directory is not included in `dist` on `yarn build`. 

## 💊 Fixes / Solution

Add the dir in the dist output

## 🚧 Changes

- Copy `public` to `dist` when building the app

## 🛠️ Tests

- Run `yarn build`
- `public` directory should appear in `dist`