### PR TITLE
fix: return 404 JSON RPC error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import api from './api';
 import webhook from './webhook';
 import './lib/queue';
 import { name, version } from '../package.json';
+import { rpcError } from './helpers/utils';
 
 const app = express();
 const PORT = process.env.PORT || 3005;
@@ -34,6 +35,10 @@ app.get('/', (req, res) => {
     name,
     version: v
   });
+});
+
+app.use((_, res) => {
+  rpcError(res, 'RECORD_NOT_FOUND', '');
 });
 
 app.listen(PORT, () => console.log(`[http] Start server at http://localhost:${PORT}`));


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

Error caught and throw by the app are formatted using JSON RPC.
Express default 404 error (for non-existing routes) are formatted using HTML.

Currently, 404 errors are returned in both JSON RPC and HTML format. Errors response should always use the same format, for consistency, and avoid parsing error from caller.

## 💊 Fixes / Solution

Default 404 Error responses from express should follow the JSON RPC format, like the rest of the endpoint.

## 🚧 Changes

- Add catch-all routes, to always return the page not found error using JSON RPC

## 🛠️ Tests

- Visit `localhost:3005/test`
- It should return a 404 error, JSON RPC formatted