### PR TITLE
chore add cache cleaner

### DIFF
--- a/scripts/clear-cache.ts
+++ b/scripts/clear-cache.ts
@@ -2,20 +2,23 @@ import 'dotenv/config';
 import { storageEngine } from '../src/helpers/utils';
 
 /**
- * Display the contents of the cached storage engine,
+ * Clear all the cached files in the storage engine,
  * as configured in .env
  */
 async function main() {
   if (process.argv.length < 2) {
-    console.error(`Usage: yarn ts-node scripts/list-cache.ts`);
+    console.error(`Usage: yarn ts-node scripts/clear-cache.ts`);
     return process.exit(1);
   }
 
   const engine = storageEngine(process.env.VOTE_REPORT_SUBDIR);
   const list = await engine.list();
 
-  console.log(`> Found ${list.length} cached items`);
-  console.log(list);
+  console.log(`> Deleting ${list.length} cached files on ${engine.constructor.name}`);
+  await engine.clear();
+
+  const finalList = await engine.list();
+  console.log(`> Finished! ${finalList.length} files remaining`);
 }
 
 (async () => {

--- a/scripts/list-cache.ts
+++ b/scripts/list-cache.ts
@@ -1,0 +1,23 @@
+import 'dotenv/config';
+import { storageEngine } from '../src/helpers/utils';
+
+async function main() {
+  if (process.argv.length < 2) {
+    console.error(`Usage: yarn ts-node scripts/list-cache.ts`);
+    return process.exit(1);
+  }
+
+  const engine = storageEngine(process.env.VOTE_REPORT_SUBDIR);
+
+  console.log(await engine.list());
+}
+
+(async () => {
+  try {
+    await main();
+    process.exit(0);
+  } catch (e) {
+    console.error(e);
+    process.exit(1);
+  }
+})();

--- a/src/lib/storage/aws.ts
+++ b/src/lib/storage/aws.ts
@@ -2,7 +2,8 @@ import {
   S3Client,
   GetObjectCommand,
   PutObjectCommand,
-  ListObjectsV2Command
+  ListObjectsV2Command,
+  DeleteObjectCommand
 } from '@aws-sdk/client-s3';
 import type { IStorage } from './types';
 
@@ -62,13 +63,41 @@ class Aws implements IStorage {
   async list() {
     try {
       const command = new ListObjectsV2Command({
-        Bucket: process.env.AWS_BUCKET_NAME
+        Bucket: process.env.AWS_BUCKET_NAME,
+        Prefix: this.#path()
+      });
+      const list = await this.client.send(command);
+
+      return list.Contents || [];
+    } catch (e) {
+      console.error('[storage:aws] List failed', e);
+      return [];
+    }
+  }
+
+  async delete(key: string): Promise<any> {
+    try {
+      const command = new DeleteObjectCommand({
+        Bucket: process.env.AWS_BUCKET_NAME,
+        Key: key
       });
       return await this.client.send(command);
     } catch (e) {
-      console.error('[storage:aws] List fetch failed', e);
+      console.error('[storage:aws] File delete failed', e);
       return false;
     }
+  }
+
+  async clear() {
+    const items = await this.list();
+
+    items.map(item => {
+      if (item.Key) {
+        this.delete(item.Key);
+      }
+    });
+
+    return true;
   }
 
   #path(key?: string) {

--- a/src/lib/storage/aws.ts
+++ b/src/lib/storage/aws.ts
@@ -1,4 +1,9 @@
-import { S3Client, GetObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3';
+import {
+  S3Client,
+  GetObjectCommand,
+  PutObjectCommand,
+  ListObjectsV2Command
+} from '@aws-sdk/client-s3';
 import type { IStorage } from './types';
 
 const CACHE_PATH = 'public';
@@ -50,6 +55,18 @@ class Aws implements IStorage {
       return response.Body?.transformToString() || false;
     } catch (e) {
       console.error('[storage:aws] File fetch failed', e);
+      return false;
+    }
+  }
+
+  async list() {
+    try {
+      const command = new ListObjectsV2Command({
+        Bucket: process.env.AWS_BUCKET_NAME
+      });
+      return await this.client.send(command);
+    } catch (e) {
+      console.error('[storage:aws] List fetch failed', e);
       return false;
     }
   }

--- a/src/lib/storage/file.ts
+++ b/src/lib/storage/file.ts
@@ -1,4 +1,4 @@
-import { writeFileSync, existsSync, mkdirSync, readFileSync, readdirSync } from 'fs';
+import { writeFileSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync } from 'fs';
 import type { IStorage } from './types';
 
 const CACHE_PATH = `${__dirname}/../../../tmp`;
@@ -12,6 +12,10 @@ class File implements IStorage {
     if (!existsSync(this.#path())) {
       mkdirSync(this.#path(), { recursive: true });
     }
+  }
+
+  clearAll(): Promise<boolean> {
+    throw new Error('Method not implemented.');
   }
 
   async set(key: string, value: string) {
@@ -39,8 +43,32 @@ class File implements IStorage {
     }
   }
 
+  async delete(key: string) {
+    try {
+      return rmSync(this.#path(key));
+    } catch (e) {
+      console.error('[storage:file] Fetch delete failed', e);
+      return false;
+    }
+  }
+
   async list() {
-    return readdirSync(this.#path());
+    try {
+      return readdirSync(this.#path());
+    } catch (e) {
+      console.error('[storage:file] List failed', e);
+      return [];
+    }
+  }
+
+  async clear() {
+    const items = await this.list();
+
+    items.map(item => {
+      this.delete(item);
+    });
+
+    return true;
   }
 
   #path(key?: string) {

--- a/src/lib/storage/file.ts
+++ b/src/lib/storage/file.ts
@@ -1,4 +1,4 @@
-import { writeFileSync, existsSync, mkdirSync, readFileSync } from 'fs';
+import { writeFileSync, existsSync, mkdirSync, readFileSync, readdirSync } from 'fs';
 import type { IStorage } from './types';
 
 const CACHE_PATH = `${__dirname}/../../../tmp`;
@@ -37,6 +37,10 @@ class File implements IStorage {
       console.error('[storage:file] Fetch file failed', e);
       return false;
     }
+  }
+
+  async list() {
+    return readdirSync(this.#path());
   }
 
   #path(key?: string) {

--- a/src/lib/storage/types.ts
+++ b/src/lib/storage/types.ts
@@ -3,7 +3,9 @@ export interface IStorage {
 
   set(key: string, value: string): Promise<unknown>;
   get(key: string): Promise<unknown>;
+  delete(key: string): Promise<any>;
   list(): Promise<any>;
+  clear(): Promise<boolean>;
 }
 
 export interface IStorageConstructor {

--- a/src/lib/storage/types.ts
+++ b/src/lib/storage/types.ts
@@ -3,6 +3,7 @@ export interface IStorage {
 
   set(key: string, value: string): Promise<unknown>;
   get(key: string): Promise<unknown>;
+  list(): Promise<any>;
 }
 
 export interface IStorageConstructor {


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

There is now way to delete all cached contents, in case there was an issue, producing bugged cached contents.

## 💊 Fixes / Solution

Add a dev script to manually trigger cache clearing. Script only for dev use, and can not be run on prod.

## 🚧 Changes

- Add script to list the contents of the cache
- Add script to clear the whole cache

## 🛠️ Tests

> To be run only on your locally configured dev storage engine. Do not test with prod settings in your .env or you will wipe the prod cache

Recommend to set your storage engine to `file`, and add some dummy files to `tmp/votes`.

- `yarn ts-node scripts/list-cache.ts` to list the cache contents
- `yarn ts-node scripts/clear-cache.ts` to clear the cache
