### PR TITLE
fix: do not throw an error when cached file does not exist

### DIFF
--- a/src/lib/storage/aws.ts
+++ b/src/lib/storage/aws.ts
@@ -48,8 +48,11 @@ class Aws implements IStorage {
       const response = await this.client.send(command);
 
       return response.Body?.transformToString() || false;
-    } catch (e) {
-      console.error('[storage:aws] File fetch failed', e);
+    } catch (e: any) {
+      if (e['$metadata']?.httpStatusCode !== 404) {
+        console.error('[storage:aws] File fetch failed', e);
+      }
+
       return false;
     }
   }


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

We're using fetch directly to get a cached file from AWS, and do not check for cache existence first. Any error returned while fetching the file is considered as cache not existing, and will continue to cache creation

`get` should not raise an error, and should only return `false` when the cache file does not exist (like in the `File` cache engine)

## 💊 Fixes / Solution

When the `get` command from AWS fail with a 404 error, just return `false`, and do not raise an error. (Do not pollute the logs)

## 🚧 Changes

- Add check to not log the error on cache file fetching failure, when cache do not exist

## 🛠️ Tests

- Try to trigger a votes CSV file creation, for a proposal ID not existing on AWS yet
- It should not console.error the error