### PR TITLE
chore: downgrade dependencies causing tests to fail

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@ethersproject/bignumber": "^5.7.0",
     "@ethersproject/transactions": "^5.7.0",
     "@ethersproject/wallet": "^5.7.0",
-    "@snapshot-labs/snapshot.js": "^0.4.97",
+    "@snapshot-labs/snapshot.js": "0.4.97",
     "bluebird": "^3.7.2",
     "compression": "^1.7.4",
     "connection-string": "^4.3.6",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@ethersproject/bignumber": "^5.7.0",
     "@ethersproject/transactions": "^5.7.0",
     "@ethersproject/wallet": "^5.7.0",
-    "@snapshot-labs/snapshot.js": "^0.4.98",
+    "@snapshot-labs/snapshot.js": "^0.4.97",
     "bluebird": "^3.7.2",
     "compression": "^1.7.4",
     "connection-string": "^4.3.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2006,10 +2006,10 @@
   resolved "https://registry.yarnpkg.com/@snapshot-labs/prettier-config/-/prettier-config-0.1.0-beta.7.tgz#c8e07e7e9baabee245020a72ac05835b65139823"
   integrity sha512-k/FUf4VWhwLFUmKuWs2mNvmPe691hqhvCJuujD4TfbIivWysmL1TqthwfdQUrQEAQUqVQ2ZKEiGkbufp5J27eQ==
 
-"@snapshot-labs/snapshot.js@^0.4.98":
-  version "0.4.98"
-  resolved "https://registry.yarnpkg.com/@snapshot-labs/snapshot.js/-/snapshot.js-0.4.98.tgz#6e2e85c09015a28cc6024b6ae98304d41833960d"
-  integrity sha512-4slGeX1TW+R3dsTZfn/GrfgfuRMVW7d9HUsX5bqBMH3RPV57PtMCrKagvZZiaHQcNh7jww5I+pW69Q05n6lOrg==
+"@snapshot-labs/snapshot.js@^0.4.97":
+  version "0.4.101"
+  resolved "https://registry.yarnpkg.com/@snapshot-labs/snapshot.js/-/snapshot.js-0.4.101.tgz#4d6914d6b2c7026577fea3eab2277c5c40cfbe45"
+  integrity sha512-Zy6qXyUznFpzfQNjhs/ej0ORX5KYM/JyH2GGqe9cXJMS1PxJwxFz3olhaoiMNCmDhAif/TXcWusim+k72wO2qA==
   dependencies:
     "@ensdomains/eth-ens-namehash" "^2.0.15"
     "@ethersproject/abi" "^5.6.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2006,10 +2006,10 @@
   resolved "https://registry.yarnpkg.com/@snapshot-labs/prettier-config/-/prettier-config-0.1.0-beta.7.tgz#c8e07e7e9baabee245020a72ac05835b65139823"
   integrity sha512-k/FUf4VWhwLFUmKuWs2mNvmPe691hqhvCJuujD4TfbIivWysmL1TqthwfdQUrQEAQUqVQ2ZKEiGkbufp5J27eQ==
 
-"@snapshot-labs/snapshot.js@^0.4.97":
-  version "0.4.101"
-  resolved "https://registry.yarnpkg.com/@snapshot-labs/snapshot.js/-/snapshot.js-0.4.101.tgz#4d6914d6b2c7026577fea3eab2277c5c40cfbe45"
-  integrity sha512-Zy6qXyUznFpzfQNjhs/ej0ORX5KYM/JyH2GGqe9cXJMS1PxJwxFz3olhaoiMNCmDhAif/TXcWusim+k72wO2qA==
+"@snapshot-labs/snapshot.js@0.4.97":
+  version "0.4.97"
+  resolved "https://registry.yarnpkg.com/@snapshot-labs/snapshot.js/-/snapshot.js-0.4.97.tgz#1df919e4c3a7b97f3ea2c82478400981c6702a50"
+  integrity sha512-EdEyZ7r5SQo2FBjnDM9rzULQz6wMTo1sZFnFpYRSDSddNk+bn16SqosI5amr7o9UHqz1aZPltv3ivjqNszr9hg==
   dependencies:
     "@ensdomains/eth-ens-namehash" "^2.0.15"
     "@ethersproject/abi" "^5.6.4"


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

Jest tests are failing due to last version of snapshot.js

## 💊 Fixes / Solution

Downgrade the version of snapshot.js used

## 🚧 Changes

- Downgrade snapshot.js to `0.4.97`

## 🛠️ Tests

- Run `yarn test`
- They should not complain about async task not completed
- They should complete and succeed on Github actions
