### PR TITLE
chore: enable sentry only on prod

### DIFF
--- a/src/helpers/sentry.ts
+++ b/src/helpers/sentry.ts
@@ -3,7 +3,7 @@ import type { Express } from 'express';
 
 export function initLogger(app: Express) {
   if (process.env.NODE_ENV !== 'production') {
-    return false;
+    return;
   }
 
   Sentry.init({

--- a/src/helpers/sentry.ts
+++ b/src/helpers/sentry.ts
@@ -22,6 +22,10 @@ export function initLogger(app: Express) {
 }
 
 export function fallbackLogger(app: Express) {
+  if (process.env.NODE_ENV !== 'production') {
+    return;
+  }
+
   app.use(Sentry.Handlers.errorHandler());
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   app.use(function onError(err: any, req: any, res: any, _: any) {
@@ -31,5 +35,9 @@ export function fallbackLogger(app: Express) {
 }
 
 export function capture(e: any) {
+  if (process.env.NODE_ENV !== 'production') {
+    return console.error(e);
+  }
+
   Sentry.captureException(e);
 }

--- a/src/helpers/sentry.ts
+++ b/src/helpers/sentry.ts
@@ -2,6 +2,10 @@ import * as Sentry from '@sentry/node';
 import type { Express } from 'express';
 
 export function initLogger(app: Express) {
+  if (process.env.NODE_ENV !== 'production') {
+    return false;
+  }
+
   Sentry.init({
     dsn: process.env.SENTRY_DSN,
     integrations: [


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

Sentry is always enabled, as long as DSN is set, and may send errors when developing on local.

## 💊 Fixes / Solution

- Enable sentry logger only on production

## 🚧 Changes

- Add a condition to enable sentry only on prod, by checking `NODE_ENV`
- `NODE_ENV` have been set to `production` on the prod server

## 🛠️ Tests

- N/A