### PR TITLE
feat: add flagged IPs to moderation list

### DIFF
--- a/src/lib/moderationList.ts
+++ b/src/lib/moderationList.ts
@@ -9,6 +9,7 @@ const FIELDS = new Map<keyof MODERATION_LIST, Record<string, string>>([
   ['flaggedLinks', { action: 'flag', type: 'link' }],
   ['flaggedProposals', { action: 'flag', type: 'proposal' }],
   ['flaggedSpaces', { action: 'flag', type: 'space' }],
+  ['flaggedIps', { action: 'flag', type: 'ip' }],
   ['verifiedSpaces', { action: 'verify', type: 'space' }],
   ['verifiedTokens', { file: 'verifiedTokens.json' }]
 ]);

--- a/test/e2e/__snapshots__/moderation.test.ts.snap
+++ b/test/e2e/__snapshots__/moderation.test.ts.snap
@@ -24,6 +24,10 @@ exports[`GET /api/moderation returns multiple list: verifiedSpaces,flaggedPropos
 
 exports[`GET /api/moderation when list params is empty returns all the list 1`] = `
 {
+  "flaggedIps": [
+    "12ca17b49af2289436f303e0166030a21e525d266e209267433801a8fd4071a0",
+    "19e36255972107d42b8cecb77ef5622e842e8a50778a6ed8dd1ce94732daca9e",
+  ],
   "flaggedLinks": [
     "https://facebook.com",
     "https://gogle.com",

--- a/test/fixtures/moderation.ts
+++ b/test/fixtures/moderation.ts
@@ -12,6 +12,20 @@ export const SqlFixtures: Record<string, any[]> = {
     { action: 'flag', type: 'space', value: 'space3.eth', created: 100 },
     { action: 'flag', type: 'space', value: 'space4.eth', created: 100 }
   ],
+  flaggedIps: [
+    {
+      action: 'flag',
+      type: 'ip',
+      value: '12ca17b49af2289436f303e0166030a21e525d266e209267433801a8fd4071a0',
+      created: 100
+    },
+    {
+      action: 'flag',
+      type: 'ip',
+      value: '19e36255972107d42b8cecb77ef5622e842e8a50778a6ed8dd1ce94732daca9e',
+      created: 100
+    }
+  ],
   verifiedSpaces: [
     { action: 'verify', type: 'space', value: 'space1.eth', created: 100 },
     { action: 'verify', type: 'space', value: 'space2.eth', created: 100 }

--- a/test/unit/lib/__snapshots__/moderationList.test.ts.snap
+++ b/test/unit/lib/__snapshots__/moderationList.test.ts.snap
@@ -11,6 +11,10 @@ exports[`moderationList ignores invalid fields, and only returns verifiedSpaces 
 
 exports[`moderationList returns all fields by default 1`] = `
 {
+  "flaggedIps": [
+    "12ca17b49af2289436f303e0166030a21e525d266e209267433801a8fd4071a0",
+    "19e36255972107d42b8cecb77ef5622e842e8a50778a6ed8dd1ce94732daca9e",
+  ],
   "flaggedLinks": [
     "https://gogle.com",
     "https://facebook.com",


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

Moderation list endpoint is not returning the list of flagged IPs
This is follow-up of https://github.com/snapshot-labs/laser/pull/1

## 💊 Fixes / Solution

- Return the list of flagged IPs

## 🚧 Changes

- Add support for returning the list of flagged Ips

## 🛠️ Tests

- Add a flagged IP in your database 
- Poll the `/api/moderation` endpoint 
- It should return the flagged IP from your database 