### PR TITLE
chore: remove errors granularity

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,9 +319,7 @@ All endpoints will respond with a [JSON-RPC 2.0](https://www.jsonrpc.org/specifi
 
 | Description                         | `CODE` | `MESSAGE`            |
 | ----------------------------------- | ------ | -------------------- |
-| When the proposal does not exist    | 404    | PROPOSAL_NOT_FOUND   |
 | When the record does not exist      | 404    | RECORD_NOT_FOUND     |
-| When the proposal is not closed     | -40004 | PROPOSAL_NOT_CLOSED  |
 | When the file is pending generation | 202    | PENDING_GENERATION   |
 | Other/Unknown/Server Error          | -32603 | INTERNAL_ERROR       |
 | Other error                         | 500    | Depends on the error |

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -4,8 +4,6 @@ import type { Response } from 'express';
 
 const ERROR_CODES: Record<string, number> = {
   'Invalid Request': -32600,
-  PROPOSAL_NOT_FOUND: 404,
-  PROPOSAL_NOT_CLOSED: -40004,
   RECORD_NOT_FOUND: 404,
   UNAUTHORIZED: 401
 };

--- a/src/lib/votesReport.ts
+++ b/src/lib/votesReport.ts
@@ -24,11 +24,11 @@ class VotesReport {
     this.proposal = await this.fetchProposal();
 
     if (!this.proposal) {
-      return Promise.reject('PROPOSAL_NOT_FOUND');
+      return Promise.reject('RECORD_NOT_FOUND');
     }
 
     if (this.proposal.state !== 'closed') {
-      return Promise.reject('PROPOSAL_NOT_CLOSED');
+      return Promise.reject('RECORD_NOT_FOUND');
     }
 
     return true;

--- a/test/unit/lib/votesReport.test.ts
+++ b/test/unit/lib/votesReport.test.ts
@@ -59,7 +59,7 @@ describe('VotesReport', () => {
       const report = new VotesReport('test', _storageEngine);
       const votesReportSpy = jest.spyOn(report, 'fetchProposal').mockResolvedValueOnce(null);
 
-      expect(report.canBeCached()).rejects.toBe('PROPOSAL_NOT_FOUND');
+      expect(report.canBeCached()).rejects.toBe('RECORD_NOT_FOUND');
       expect(votesReportSpy).toHaveBeenCalled();
     });
 
@@ -74,7 +74,7 @@ describe('VotesReport', () => {
         space
       });
 
-      expect(report.canBeCached()).rejects.toBe('PROPOSAL_NOT_CLOSED');
+      expect(report.canBeCached()).rejects.toBe('RECORD_NOT_FOUND');
       expect(votesReportSpy).toHaveBeenCalled();
     });
 


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

There's currently different error codes for different type of errors, such as `PROPOSAL_NOT_FOUND` and `PROPOSAL_NOT_CLOSED`.

API endpoint has evolved such that we do not return these errors anymore, and prefer to return a generic 404 error.

## 💊 Fixes / Solution

- Removed unused error codes

## 🚧 Changes

- Remove `PROPOSAL_NOT_FOUND` and `PROPOSAL_NOT_CLOSED` error code, and always use generic `RECORD_NOT_FOUND` for record not found error.

## 🛠️ Tests

