### PR TITLE
feat: return new flagged items

### DIFF
--- a/src/lib/moderationList.ts
+++ b/src/lib/moderationList.ts
@@ -10,6 +10,9 @@ const FIELDS = new Map<keyof MODERATION_LIST, Record<string, string>>([
   ['flaggedProposals', { action: 'flag', type: 'proposal' }],
   ['flaggedSpaces', { action: 'flag', type: 'space' }],
   ['flaggedIps', { action: 'flag', type: 'ip' }],
+  ['flaggedAddresses', { action: 'flag', type: 'address' }],
+  ['flaggedProposalTitleKeyword', { action: 'flag', type: 'proposalTitleKeyword' }],
+  ['flaggedProposalBodyKeyword', { action: 'flag', type: 'proposalBodyKeyword' }],
   ['verifiedSpaces', { action: 'verify', type: 'space' }],
   ['verifiedTokens', { file: 'verifiedTokens.json' }]
 ]);

--- a/test/e2e/__snapshots__/moderation.test.ts.snap
+++ b/test/e2e/__snapshots__/moderation.test.ts.snap
@@ -24,6 +24,10 @@ exports[`GET /api/moderation returns multiple list: verifiedSpaces,flaggedPropos
 
 exports[`GET /api/moderation when list params is empty returns all the list 1`] = `
 {
+  "flaggedAddresses": [
+    "0x0001",
+    "0x0002",
+  ],
   "flaggedIps": [
     "12ca17b49af2289436f303e0166030a21e525d266e209267433801a8fd4071a0",
     "19e36255972107d42b8cecb77ef5622e842e8a50778a6ed8dd1ce94732daca9e",
@@ -31,6 +35,14 @@ exports[`GET /api/moderation when list params is empty returns all the list 1`] 
   "flaggedLinks": [
     "https://facebook.com",
     "https://gogle.com",
+  ],
+  "flaggedProposalBodyKeyword": [
+    "claim drop",
+    "token",
+  ],
+  "flaggedProposalTitleKeyword": [
+    "hello",
+    "test string",
   ],
   "flaggedProposals": [
     "0x1",

--- a/test/fixtures/moderation.ts
+++ b/test/fixtures/moderation.ts
@@ -12,6 +12,18 @@ export const SqlFixtures: Record<string, any[]> = {
     { action: 'flag', type: 'space', value: 'space3.eth', created: 100 },
     { action: 'flag', type: 'space', value: 'space4.eth', created: 100 }
   ],
+  flaggedAddresses: [
+    { action: 'flag', type: 'address', value: '0x0001', created: 100 },
+    { action: 'flag', type: 'address', value: '0x0002', created: 100 }
+  ],
+  flaggedProposalTitleKeyword: [
+    { action: 'flag', type: 'proposalTitleKeyword', value: 'hello', created: 100 },
+    { action: 'flag', type: 'proposalTitleKeyword', value: 'test string', created: 100 }
+  ],
+  flaggedProposalBodyKeyword: [
+    { action: 'flag', type: 'proposalBodyKeyword', value: 'claim drop', created: 100 },
+    { action: 'flag', type: 'proposalBodyKeyword', value: 'token', created: 100 }
+  ],
   flaggedIps: [
     {
       action: 'flag',

--- a/test/unit/lib/__snapshots__/moderationList.test.ts.snap
+++ b/test/unit/lib/__snapshots__/moderationList.test.ts.snap
@@ -11,6 +11,10 @@ exports[`moderationList ignores invalid fields, and only returns verifiedSpaces 
 
 exports[`moderationList returns all fields by default 1`] = `
 {
+  "flaggedAddresses": [
+    "0x0001",
+    "0x0002",
+  ],
   "flaggedIps": [
     "12ca17b49af2289436f303e0166030a21e525d266e209267433801a8fd4071a0",
     "19e36255972107d42b8cecb77ef5622e842e8a50778a6ed8dd1ce94732daca9e",
@@ -18,6 +22,14 @@ exports[`moderationList returns all fields by default 1`] = `
   "flaggedLinks": [
     "https://gogle.com",
     "https://facebook.com",
+  ],
+  "flaggedProposalBodyKeyword": [
+    "claim drop",
+    "token",
+  ],
+  "flaggedProposalTitleKeyword": [
+    "hello",
+    "test string",
   ],
   "flaggedProposals": [
     "0x1",


### PR DESCRIPTION
Return new flagged items from laser:

- flaggedAddresses
- flaggedProposalTitleKeywords
- flaggedProposalBodyKeywords