### PR TITLE
fix: mute error when the digital ocean API key is missing

### DIFF
--- a/src/lib/metrics/digitalOcean.ts
+++ b/src/lib/metrics/digitalOcean.ts
@@ -13,7 +13,7 @@ export default class DigitalOcean {
     this.key = process.env.DIGITAL_OCEAN_TOKEN;
 
     if (!this.key) {
-      throw new Error('[metrics:digital-ocean] Digital Ocean token is missing');
+      throw new Error('MISSING_KEY');
     }
   }
 

--- a/src/lib/metrics/index.ts
+++ b/src/lib/metrics/index.ts
@@ -157,6 +157,8 @@ async function initCustomMetrics() {
       }
     });
   } catch (e: any) {
-    capture(e);
+    if (e.message !== 'MISSING_KEY') {
+      capture(e);
+    }
   }
 }


### PR DESCRIPTION
When API key is not set, it should fail silently, as missing API key also means that feature is disabled.