### PR TITLE
chore: whitelist http request from metrics

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: 'npm'
-    directory: '/'
-    schedule:
-      interval: 'weekly'

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ const PORT = process.env.PORT || 3005;
 initLogger(app);
 initMetrics(app);
 
+app.disable('x-powered-by');
 app.use(express.json({ limit: '4mb' }));
 app.use(cors({ maxAge: 86400 }));
 app.use(compression());

--- a/src/lib/metrics/index.ts
+++ b/src/lib/metrics/index.ts
@@ -39,6 +39,13 @@ new client.Gauge({
   }
 });
 
+export const timeQueueProcess = new client.Histogram({
+  name: 'queue_process_duration_seconds',
+  help: 'Duration in seconds of each queue process',
+  labelNames: ['name'],
+  buckets: [3, 7, 10, 15, 30, 60, 120]
+});
+
 try {
   const digitalOcean = new DigitalOcean();
 

--- a/src/lib/metrics/index.ts
+++ b/src/lib/metrics/index.ts
@@ -1,12 +1,21 @@
 import init, { client } from '@snapshot-labs/snapshot-metrics';
+import { capture } from '@snapshot-labs/snapshot-sentry';
 import { size as queueSize } from '../queue';
 import getModerationList from '../moderationList';
 import DigitalOcean from './digitalOcean';
-import { capture } from '@snapshot-labs/snapshot-sentry';
 import type { Express } from 'express';
 
 export default function initMetrics(app: Express) {
-  init(app);
+  init(app, {
+    normalizedPath: [['^/api/votes/.*', '/api/votes/#id']],
+    whitelistedPath: [
+      /^\/$/,
+      /^\/api\/votes\/.*$/,
+      /^\/api\/(nft-claimer)(\/(deploy|mint))?$/,
+      /^\/api\/moderation$/,
+      /^\/(webhook|sentry)$/
+    ]
+  });
 }
 
 new client.Gauge({


### PR DESCRIPTION
- whitelist endpoints for http metrics, currently getting a lot of spam, skewing the results
- normalize metrics path, so /votes/1 and /votes/2 are counted together
- add queue process time to metrics
- remove powered by express header
- remove dependabot