### PR TITLE
chore: removed unused dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,12 +42,10 @@
     "cors": "^2.8.5",
     "cross-fetch": "^4.0.0",
     "express": "^4.18.2",
-    "express-prom-bundle": "^6.6.0",
     "graphql": "^16.7.1",
     "morgan": "^1.10.0",
     "multiformats": "^9",
-    "mysql": "^2.18.1",
-    "prom-client": "^14.2.0"
+    "mysql": "^2.18.1"
   },
   "devDependencies": {
     "@snapshot-labs/eslint-config": "^0.1.0-beta.9",


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

There's dependency leftover, from metrics, when the package was migrated to @snapshot-labs/snapshot-metrics. Old dependency were not removed cleanly

## 💊 Fixes / Solution

- Remove old unused dependency, obsolete now that we've migrated to @snapshot-labs/snapshot-metrics

## 🚧 Changes

- Remove `express-prom-bundle` and `prom-client` dependency, which were now moved to `@snapshot-labs/snapshot-metrics`

## 🛠️ Tests

- N/A