### PR TITLE
chore: edit dependabot to only update org packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+    allow:
+      - dependency-name: '@snapshot-labs/*'


### PR DESCRIPTION
This PR update dependabot config to:
- increase the update frequency to daily instead of weekly
- only update packages from @snapshot-labs 

To be inline with config from other repo
