### PR TITLE
fix: restrict NFT minting only to voter

### DIFF
--- a/src/helpers/snapshot.ts
+++ b/src/helpers/snapshot.ts
@@ -100,6 +100,14 @@ const VOTES_QUERY = gql`
   }
 `;
 
+const VOTE_QUERY = gql`
+  query Votes($voter: String!, $proposalId: String!) {
+    votes(first: 1, where: { voter: $voter, proposal: $proposalId }) {
+      id
+    }
+  }
+`;
+
 const SPACE_QUERY = gql`
   query Space($id: String) {
     space(id: $id) {
@@ -141,6 +149,20 @@ export async function fetchVotes(
   });
 
   return votes;
+}
+
+export async function fetchVote(voter: string, proposalId: string) {
+  const {
+    data: { votes }
+  }: { data: { votes: Vote[] } } = await client.query({
+    query: VOTE_QUERY,
+    variables: {
+      voter,
+      proposalId
+    }
+  });
+
+  return votes[0];
 }
 
 export async function fetchSpace(id: string) {

--- a/src/lib/nftClaimer/mint.ts
+++ b/src/lib/nftClaimer/mint.ts
@@ -1,12 +1,13 @@
 import { splitSignature } from '@ethersproject/bytes';
-import { fetchProposal, Space } from '../../helpers/snapshot';
+import { fetchProposal, Space, Proposal } from '../../helpers/snapshot';
 import {
   validateProposal,
   getProposalContract,
   signer,
   numberizeProposalId,
   validateMintInput,
-  mintingAllowed
+  mintingAllowed,
+  hasVoted
 } from './utils';
 import abi from './spaceCollectionImplementationAbi.json';
 import { FormatTypes, Interface } from '@ethersproject/abi';
@@ -37,6 +38,10 @@ export default async function payload(input: {
   const verifyingContract = await getProposalContract(spaceId);
   if (!mintingAllowed(proposal?.space as Space)) {
     throw new Error('Space has closed minting');
+  }
+
+  if (!hasVoted(params.recipient, proposal as Proposal)) {
+    throw new Error('Minting is open only for voters');
   }
 
   const message = {

--- a/src/lib/nftClaimer/mint.ts
+++ b/src/lib/nftClaimer/mint.ts
@@ -40,7 +40,7 @@ export default async function payload(input: {
     throw new Error('Space has closed minting');
   }
 
-  if (!hasVoted(params.recipient, proposal as Proposal)) {
+  if (!(await hasVoted(params.recipient, proposal as Proposal))) {
     throw new Error('Minting is open only for voters');
   }
 

--- a/src/lib/nftClaimer/utils.ts
+++ b/src/lib/nftClaimer/utils.ts
@@ -6,7 +6,7 @@ import { Contract } from '@ethersproject/contracts';
 import { getAddress, isAddress } from '@ethersproject/address';
 import { BigNumber } from '@ethersproject/bignumber';
 import { capture } from '@snapshot-labs/snapshot-sentry';
-import type { Proposal, Space } from '../../helpers/snapshot';
+import { fetchVote, type Proposal, type Space } from '../../helpers/snapshot';
 import { fetchWithKeepAlive } from '../../helpers/utils';
 
 const requiredEnvKeys = [
@@ -41,6 +41,11 @@ export const signer = new Wallet(process.env.NFT_CLAIMER_PRIVATE_KEY as string);
 
 export async function mintingAllowed(space: Space) {
   return (await getSpaceCollection(space.id)).enabled;
+}
+
+export async function hasVoted(address: string, proposal: Proposal) {
+  const vote = await fetchVote(address, proposal.id);
+  return vote !== undefined;
 }
 
 export async function validateSpace(address: string, space: Space | null) {

--- a/test/integration/lib/nftClaimer/utils.test.ts
+++ b/test/integration/lib/nftClaimer/utils.test.ts
@@ -1,0 +1,22 @@
+import { Proposal } from '../../../../src/helpers/snapshot';
+import { hasVoted } from '../../../../src/lib/nftClaimer/utils';
+
+describe('nftClaimer/utils', () => {
+  describe('hasVoted()', () => {
+    it('returns true when the address has voted on the given proposal', () => {
+      expect(
+        hasVoted('0x96176C25803Ce4cF046aa74895646D8514Ea1611', {
+          id: 'QmPvbwguLfcVryzBRrbY4Pb9bCtxURagdv1XjhtFLf3wHj'
+        } as Proposal)
+      ).resolves.toBe(true);
+    });
+
+    it('returns false when the address has not voted on the given proposal', () => {
+      expect(
+        hasVoted('0x96176C25803Ce4cF046aa74895646D8514Ea1611', {
+          id: '0xcf201ad7a32dcd399654c476093f079554dae429a13063f50d839e5621cd2e6e'
+        } as Proposal)
+      ).resolves.toBe(false);
+    });
+  });
+});

--- a/test/unit/lib/nftClaimer/mint.test.ts
+++ b/test/unit/lib/nftClaimer/mint.test.ts
@@ -32,6 +32,10 @@ const mockValidateProposal = jest.fn((proposal: any): void => {
 const mockMintingAllowed = jest.fn((space: any): boolean => {
   return true;
 });
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const mockHasVoted = jest.fn((address: string, proposal: string): boolean => {
+  return true;
+});
 jest.mock('../../../../src/lib/nftClaimer/utils', () => {
   // Require the original module to not be mocked...
   const originalModule = jest.requireActual('../../../../src/lib/nftClaimer/utils');
@@ -41,7 +45,8 @@ jest.mock('../../../../src/lib/nftClaimer/utils', () => {
     ...originalModule,
     getProposalContract: (id: string) => mockGetProposalContract(id),
     validateProposal: (id: any) => mockValidateProposal(id),
-    mintingAllowed: (space: any) => mockMintingAllowed(space)
+    mintingAllowed: (space: any) => mockMintingAllowed(space),
+    hasVoted: (address: string, proposal: string) => mockHasVoted(address, proposal)
   };
 });
 
@@ -106,6 +111,13 @@ describe('nftClaimer', () => {
     describe('when space has closed minting', () => {
       it('throws an error', () => {
         mockMintingAllowed.mockReturnValueOnce(false);
+        return expect(async () => await payload(input)).rejects.toThrow();
+      });
+    });
+
+    describe('when address has not voted on the proposal', () => {
+      it('throws an error', () => {
+        mockHasVoted.mockReturnValueOnce(false);
         return expect(async () => await payload(input)).rejects.toThrow();
       });
     });


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

First part of the following pitch: https://www.notion.so/snapshotlabs/NFT-claimer-minting-constrains-de9705b71aca4b1aa57ff62b47d1824a

## 🚧 Changes

- Restrict mint only to voter
- Add related tests

## 🛠️ Tests

- Run a local instance of this branch (Copy and set the missing env var from /test/.env.test)
- Run a local instance of snapshot https://github.com/snapshot-labs/snapshot/pull/3885 (set the `VITE_SIDEKICK_URL` in .env to your local sidekick instance)
- On a proposal you have not voted yet, if you try to mint, it should return an error
- On a proposal you have voted, if you try to mint, it should mint

As of now, the UI only return "Invalid data submitted" message on error. UI needs some refactoring to check if user already voted, and show am error another message, instead of starting the mint and failing from sidekick validation.