### PR TITLE
fix: remove flagged/verified proposals/spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,10 +155,12 @@ curl localhost:3005/api/moderation
 You can also choose to filter the list, with the `?list=` query params.
 Valid values are:
 
-- `flaggedProposals`
 - `flaggedLinks`
-- `verifiedSpaces`
-- `flaggedSpaces`
+- `flaggedIps`
+- `flaggedAddresses`
+- `flaggedProposalTitleKeywords`
+- `flaggedProposalBodyKeywords`
+- `verifiedTokens`
 
 You can pass multiple list, separated by a comma.
 

--- a/src/lib/moderationList.ts
+++ b/src/lib/moderationList.ts
@@ -7,13 +7,10 @@ type MODERATION_LIST = Record<string, string[] | JSON>;
 const CACHE_PATH = path.resolve(__dirname, `../../${process.env.MODERATION_LIST_PATH || 'data'}`);
 const FIELDS = new Map<keyof MODERATION_LIST, Record<string, string>>([
   ['flaggedLinks', { action: 'flag', type: 'link' }],
-  ['flaggedProposals', { action: 'flag', type: 'proposal' }],
-  ['flaggedSpaces', { action: 'flag', type: 'space' }],
   ['flaggedIps', { action: 'flag', type: 'ip' }],
   ['flaggedAddresses', { action: 'flag', type: 'address' }],
   ['flaggedProposalTitleKeywords', { action: 'flag', type: 'proposalTitleKeyword' }],
   ['flaggedProposalBodyKeywords', { action: 'flag', type: 'proposalBodyKeyword' }],
-  ['verifiedSpaces', { action: 'verify', type: 'space' }],
   ['verifiedTokens', { file: 'verifiedTokens.json' }]
 ]);
 

--- a/test/e2e/__snapshots__/moderation.test.ts.snap
+++ b/test/e2e/__snapshots__/moderation.test.ts.snap
@@ -1,23 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`GET /api/moderation ignores invalid field, and returns only verifiedSpaces 1`] = `
+exports[`GET /api/moderation ignores invalid field, and returns only flaggedLinks 1`] = `
 {
-  "verifiedSpaces": [
-    "space1.eth",
-    "space2.eth",
+  "flaggedLinks": [
+    "https://facebook.com",
+    "https://gogle.com",
   ],
 }
 `;
 
-exports[`GET /api/moderation returns multiple list: verifiedSpaces,flaggedProposals 1`] = `
+exports[`GET /api/moderation returns multiple list: flaggedLinks,flaggedIps 1`] = `
 {
-  "flaggedProposals": [
-    "0x1",
-    "0x2",
+  "flaggedIps": [
+    "12ca17b49af2289436f303e0166030a21e525d266e209267433801a8fd4071a0",
+    "19e36255972107d42b8cecb77ef5622e842e8a50778a6ed8dd1ce94732daca9e",
   ],
-  "verifiedSpaces": [
-    "space1.eth",
-    "space2.eth",
+  "flaggedLinks": [
+    "https://facebook.com",
+    "https://gogle.com",
   ],
 }
 `;
@@ -44,18 +44,6 @@ exports[`GET /api/moderation when list params is empty returns all the list 1`] 
     "hello",
     "test string",
   ],
-  "flaggedProposals": [
-    "0x1",
-    "0x2",
-  ],
-  "flaggedSpaces": [
-    "space3.eth",
-    "space4.eth",
-  ],
-  "verifiedSpaces": [
-    "space1.eth",
-    "space2.eth",
-  ],
   "verifiedTokens": {
     "test": {
       "value": "a",
@@ -69,24 +57,6 @@ exports[`GET /api/moderation when list params is set returns only the selected f
   "flaggedLinks": [
     "https://facebook.com",
     "https://gogle.com",
-  ],
-}
-`;
-
-exports[`GET /api/moderation when list params is set returns only the selected flaggedProposals list 1`] = `
-{
-  "flaggedProposals": [
-    "0x1",
-    "0x2",
-  ],
-}
-`;
-
-exports[`GET /api/moderation when list params is set returns only the selected verifiedSpaces list 1`] = `
-{
-  "verifiedSpaces": [
-    "space1.eth",
-    "space2.eth",
   ],
 }
 `;

--- a/test/e2e/moderation.test.ts
+++ b/test/e2e/moderation.test.ts
@@ -29,7 +29,7 @@ describe('GET /api/moderation', () => {
   });
 
   describe('when list params is set', () => {
-    it.each(['flaggedLinks', 'verifiedSpaces', 'flaggedProposals', 'verifiedTokens'])(
+    it.each(['flaggedLinks', 'verifiedTokens'])(
       'returns only the selected %s list',
       async field => {
         const response = await request(HOST).get(`/api/moderation?list=${field}`);
@@ -40,17 +40,15 @@ describe('GET /api/moderation', () => {
     );
   });
 
-  it('returns multiple list: verifiedSpaces,flaggedProposals', async () => {
-    const response = await request(HOST).get(
-      `/api/moderation?list=verifiedSpaces,flaggedProposals`
-    );
+  it('returns multiple list: flaggedLinks,flaggedIps', async () => {
+    const response = await request(HOST).get(`/api/moderation?list=flaggedLinks,flaggedIps`);
 
     expect(response.statusCode).toBe(200);
     expect(response.body).toMatchSnapshot();
   });
 
-  it('ignores invalid field, and returns only verifiedSpaces', async () => {
-    const response = await request(HOST).get(`/api/moderation?list=verifiedSpaces,testInvalid`);
+  it('ignores invalid field, and returns only flaggedLinks', async () => {
+    const response = await request(HOST).get(`/api/moderation?list=flaggedLinks,testInvalid`);
 
     expect(response.statusCode).toBe(200);
     expect(response.body).toMatchSnapshot();

--- a/test/fixtures/moderation.ts
+++ b/test/fixtures/moderation.ts
@@ -4,14 +4,6 @@ export const SqlFixtures: Record<string, any[]> = {
     { action: 'flag', type: 'link', value: 'https://gogle.com', created: 100 },
     { action: 'flag', type: 'link', value: 'https://facebook.com', created: 100 }
   ],
-  flaggedProposals: [
-    { action: 'flag', type: 'proposal', value: '0x1', created: 100 },
-    { action: 'flag', type: 'proposal', value: '0x2', created: 100 }
-  ],
-  flaggedSpaces: [
-    { action: 'flag', type: 'space', value: 'space3.eth', created: 100 },
-    { action: 'flag', type: 'space', value: 'space4.eth', created: 100 }
-  ],
   flaggedAddresses: [
     { action: 'flag', type: 'address', value: '0x0001', created: 100 },
     { action: 'flag', type: 'address', value: '0x0002', created: 100 }
@@ -37,9 +29,5 @@ export const SqlFixtures: Record<string, any[]> = {
       value: '19e36255972107d42b8cecb77ef5622e842e8a50778a6ed8dd1ce94732daca9e',
       created: 100
     }
-  ],
-  verifiedSpaces: [
-    { action: 'verify', type: 'space', value: 'space1.eth', created: 100 },
-    { action: 'verify', type: 'space', value: 'space2.eth', created: 100 }
   ]
 };

--- a/test/unit/lib/__snapshots__/moderationList.test.ts.snap
+++ b/test/unit/lib/__snapshots__/moderationList.test.ts.snap
@@ -1,10 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`moderationList ignores invalid fields, and only returns verifiedSpaces 1`] = `
+exports[`moderationList ignores invalid fields, and only returns flaggedIps 1`] = `
 {
-  "verifiedSpaces": [
-    "space1.eth",
-    "space2.eth",
+  "flaggedIps": [
+    "12ca17b49af2289436f303e0166030a21e525d266e209267433801a8fd4071a0",
+    "19e36255972107d42b8cecb77ef5622e842e8a50778a6ed8dd1ce94732daca9e",
   ],
 }
 `;
@@ -31,18 +31,6 @@ exports[`moderationList returns all fields by default 1`] = `
     "hello",
     "test string",
   ],
-  "flaggedProposals": [
-    "0x1",
-    "0x2",
-  ],
-  "flaggedSpaces": [
-    "space3.eth",
-    "space4.eth",
-  ],
-  "verifiedSpaces": [
-    "space1.eth",
-    "space2.eth",
-  ],
   "verifiedTokens": {
     "test": {
       "value": "a",
@@ -51,15 +39,24 @@ exports[`moderationList returns all fields by default 1`] = `
 }
 `;
 
-exports[`moderationList returns multiple list: flaggedLinks and verifiedSpaces 1`] = `
+exports[`moderationList returns multiple list: flaggedLinks and flaggedIps 1`] = `
 {
+  "flaggedIps": [
+    "12ca17b49af2289436f303e0166030a21e525d266e209267433801a8fd4071a0",
+    "19e36255972107d42b8cecb77ef5622e842e8a50778a6ed8dd1ce94732daca9e",
+  ],
   "flaggedLinks": [
     "https://gogle.com",
     "https://facebook.com",
   ],
-  "verifiedSpaces": [
-    "space1.eth",
-    "space2.eth",
+}
+`;
+
+exports[`moderationList returns only the flaggedIps 1`] = `
+{
+  "flaggedIps": [
+    "12ca17b49af2289436f303e0166030a21e525d266e209267433801a8fd4071a0",
+    "19e36255972107d42b8cecb77ef5622e842e8a50778a6ed8dd1ce94732daca9e",
   ],
 }
 `;
@@ -69,24 +66,6 @@ exports[`moderationList returns only the flaggedLinks 1`] = `
   "flaggedLinks": [
     "https://gogle.com",
     "https://facebook.com",
-  ],
-}
-`;
-
-exports[`moderationList returns only the flaggedProposals 1`] = `
-{
-  "flaggedProposals": [
-    "0x1",
-    "0x2",
-  ],
-}
-`;
-
-exports[`moderationList returns only the verifiedSpaces 1`] = `
-{
-  "verifiedSpaces": [
-    "space1.eth",
-    "space2.eth",
   ],
 }
 `;

--- a/test/unit/lib/moderationList.test.ts
+++ b/test/unit/lib/moderationList.test.ts
@@ -11,34 +11,31 @@ jest.mock('../../../src/helpers/mysql', () => ({
 }));
 
 describe('moderationList', () => {
-  it.each(['flaggedLinks', 'verifiedSpaces', 'flaggedProposals'])(
-    'returns only the %s',
-    async field => {
-      mockDbQueryAsync.mockImplementationOnce(() => {
-        return SqlFixtures[field];
-      });
-
-      const list = await getModerationList([field]);
-
-      expect(list).toMatchSnapshot();
-    }
-  );
-
-  it('returns multiple list: flaggedLinks and verifiedSpaces', async () => {
+  it.each(['flaggedLinks', 'flaggedIps'])('returns only the %s', async field => {
     mockDbQueryAsync.mockImplementationOnce(() => {
-      return SqlFixtures.flaggedLinks.concat(SqlFixtures.verifiedSpaces);
+      return SqlFixtures[field];
     });
 
-    const list = await getModerationList(['flaggedLinks', 'verifiedSpaces']);
+    const list = await getModerationList([field]);
+
     expect(list).toMatchSnapshot();
   });
 
-  it('ignores invalid fields, and only returns verifiedSpaces', async () => {
+  it('returns multiple list: flaggedLinks and flaggedIps', async () => {
     mockDbQueryAsync.mockImplementationOnce(() => {
-      return SqlFixtures.verifiedSpaces;
+      return SqlFixtures.flaggedLinks.concat(SqlFixtures.flaggedIps);
     });
 
-    const list = await getModerationList(['a', 'b', 'verifiedSpaces']);
+    const list = await getModerationList(['flaggedLinks', 'flaggedIps']);
+    expect(list).toMatchSnapshot();
+  });
+
+  it('ignores invalid fields, and only returns flaggedIps', async () => {
+    mockDbQueryAsync.mockImplementationOnce(() => {
+      return SqlFixtures.flaggedIps;
+    });
+
+    const list = await getModerationList(['a', 'b', 'flaggedIps']);
     expect(list).toMatchSnapshot();
   });
 


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

The moderation data for space and proposals have been moved from laser DB to hub DB. Getting those data from laser is now obsolete.

## 🚧 Changes

- Remove verified/flagged spaces and flagged proposals data from the moderation endpoint. 

## 🛠️ Tests

- Run `yarn dev`
- Open `localhost:3005/api/moderation`
- It should not return data for verified/flagged spaces and flagged proposals anymore

# Todo

DO NOT MERGE YET

- [x] Update sequencer to fetch moderation data from hub