### PR TITLE
feat: allow partial CSV votes reports for active proposals

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ yarn typecheck
 
 ### Votes CSV report
 
-Generate and serve votes CSV report for closed proposals.
+Generate and serve votes CSV report for active and closed proposals.
 
 > NOTE: CSV files are generated only once, then cached, making this service a cache middleware between snapshot-hub and UI
 
@@ -122,6 +122,12 @@ A JSON-RPC success with status code `202` will then be returned, with the progre
   "id":"0x5280241b4ccc9b7c5088e657a714d28fa89bd5305a1ff0abf0736438c446ae98"
 }
 ```
+
+- CSV reports will automatically be generated for closed proposals, triggered by Snapshot's webhook.
+- CSV reports for active proposals will be generated only when requested manually via the API endpoint (`/votes/:id`), and will be refreshed every 15min thereafter.
+
+NOTES: cache file for active proposals may not always contains all the votes, as new incoming votes are
+appended to the cache file asynchronously in the background.
 
 #### Generate a cache file
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,12 +10,14 @@ import './lib/queue';
 import { name, version } from '../package.json';
 import { rpcError } from './helpers/utils';
 import initMetrics from './lib/metrics';
+import initCacheRefresher from './lib/cacheRefresher';
 
 const app = express();
 const PORT = process.env.PORT || 3005;
 
 initLogger(app);
 initMetrics(app);
+initCacheRefresher();
 
 app.disable('x-powered-by');
 app.use(express.json({ limit: '4mb' }));

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -25,6 +25,8 @@ export default class Cache {
     return true;
   }
 
+  afterCreateCache() {}
+
   async createCache() {
     await this.isCacheable();
     const content = await this.getContent();
@@ -32,6 +34,7 @@ export default class Cache {
     console.log(`[votes-report] File cache ready to be saved`);
 
     this.storage.set(this.filename, content);
+    this.afterCreateCache();
 
     return content;
   }

--- a/src/lib/cacheRefresher.ts
+++ b/src/lib/cacheRefresher.ts
@@ -1,0 +1,38 @@
+import { capture } from '@snapshot-labs/snapshot-sentry';
+import VotesReport from './votesReport';
+import { sleep, storageEngine } from '../helpers/utils';
+import { queue } from './queue';
+
+const REFRESH_INTERVAL = 15 * 60 * 1e3;
+const INDEX_FILENAME = 'snapshot-active-proposals-list.csv';
+const storage = storageEngine(process.env.VOTE_REPORT_SUBDIR);
+
+async function processItems(): Promise<number> {
+  const list = await getIndex();
+
+  list.forEach((id: string) => queue(new VotesReport(id, storage)));
+
+  return list.length;
+}
+
+export async function getIndex(): Promise<string[]> {
+  const cachedList = await storage.get(INDEX_FILENAME);
+  return cachedList ? JSON.parse(cachedList.toString()) : [];
+}
+
+export async function setIndex(list: string[]) {
+  return storage.set(INDEX_FILENAME, JSON.stringify(list));
+}
+
+export default async function run() {
+  try {
+    console.log(`[cache-refresh] Refreshing active proposals cache`);
+    const count = await processItems();
+    console.log(`[cache-refresh] ${count} proposals queued for refresh`);
+  } catch (e) {
+    capture(e);
+  } finally {
+    await sleep(REFRESH_INTERVAL);
+    await run();
+  }
+}


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

Votes CSV reports are available only for closed proposals

## 💊 Fixes / Solution

Enable CSV reports for active proposals (requested by some specific users). 
Reports will be cached, and refreshed every 15 min in the background.

## 🚧 Changes

- Enable CSV reports for active proposals
- Add cache refresher task to auto refresh cache every X min
- Save the list of partial cached proposals ID in a file (stored on AWS), to track which ID to refresh, until proposal is closed.

## 🛠️ Tests

in lib/cacheRefresher.ts, edit `REFRESH_INTERVAL` to something like 30s

- Run `yarn dev`
- Run `curl -X POST localhost:3005/api/votes/ID` (replace ID with an active propopsal ID)
- It should return a 202 code if not cached yet (cache creation will be triggered in the background)
- It should return the csv content when cached
- Monitor the `yarn dev` console, it should run the `cacheRefresher` task every 30s