### PR TITLE
chore: instrument Brovider calls

### DIFF
--- a/src/lib/metrics/index.ts
+++ b/src/lib/metrics/index.ts
@@ -180,24 +180,25 @@ const wallet = new Wallet(process.env.NFT_CLAIMER_PRIVATE_KEY as string);
 
 function refreshProviderTiming() {
   Object.values(networks).forEach(async network => {
-    const end = providersTiming.startTimer({ network: network.key });
+    const { key, multicall } = network;
+    const end = providersTiming.startTimer({ network: key });
     let status = 0;
 
     try {
-      const provider = snapshot.utils.getProvider(network.key);
+      const provider = snapshot.utils.getProvider(key);
       await snapshot.utils.multicall(
-        network.key,
+        key,
         provider,
         abi,
-        [wallet.address].map(adr => [network.multicall, 'getEthBalance', [adr]]),
+        [wallet.address].map(adr => [multicall, 'getEthBalance', [adr]]),
         {
           blockTag: 'latest'
         }
       );
       status = 1;
-      providersResponseCode.set({ network: network.key }, 200);
+      providersResponseCode.set({ network: key }, 200);
     } catch (e: any) {
-      providersResponseCode.set({ network: network.key }, parseInt(e?.error?.status || 0));
+      providersResponseCode.set({ network: key }, parseInt(e?.error?.status || 0));
     } finally {
       end({ status });
     }

--- a/src/lib/metrics/index.ts
+++ b/src/lib/metrics/index.ts
@@ -227,6 +227,6 @@ async function run() {
     capture(e);
   } finally {
     await snapshot.utils.sleep(5 + 60e3);
-    await run();
+    run();
   }
 }

--- a/src/lib/metrics/index.ts
+++ b/src/lib/metrics/index.ts
@@ -226,7 +226,7 @@ async function run() {
   } catch (e) {
     capture(e);
   } finally {
-    await snapshot.utils.sleep(30e3);
+    await snapshot.utils.sleep(5 + 60e3);
     await run();
   }
 }


### PR DESCRIPTION
Instrument the response time and code from Brovider networks

Will return metrics like

```
# HELP provider_response_code Response code of each provider request
# TYPE provider_response_code gauge
provider_response_code{network="97"} 200
provider_response_code{network="137"} 200
provider_response_code{network="204"} 200
provider_response_code{network="1"} 200
provider_response_code{network="108"} 200

# HELP provider_duration_seconds Duration in seconds of each provider request
# TYPE provider_duration_seconds gauge
provider_duration_seconds{network="97",status="1"} 0.512035792
provider_duration_seconds{network="137",status="1"} 0.541225708
provider_duration_seconds{network="204",status="1"} 0.561804417
provider_duration_seconds{network="1",status="1"} 0.58473075
provider_duration_seconds{network="108",status="1"} 0.581856208
```

Those metrics will make the dashboard act as Brovider RPC node monitoring (response time, full archive node availability), and wil raise alert on some events (slow node, node down, etc ...)

Those metrics have been put in this repo instead of brovider itself, to not add more dependencies to brovider. 