### PR TITLE
fix: remove unused flagged proposals keywords from moderation

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,8 +164,6 @@ Valid values are:
 - `flaggedLinks`
 - `flaggedIps`
 - `flaggedAddresses`
-- `flaggedProposalTitleKeywords`
-- `flaggedProposalBodyKeywords`
 - `verifiedTokens`
 
 You can pass multiple list, separated by a comma.

--- a/src/lib/moderationList.ts
+++ b/src/lib/moderationList.ts
@@ -9,8 +9,6 @@ const FIELDS = new Map<keyof MODERATION_LIST, Record<string, string>>([
   ['flaggedLinks', { action: 'flag', type: 'link' }],
   ['flaggedIps', { action: 'flag', type: 'ip' }],
   ['flaggedAddresses', { action: 'flag', type: 'address' }],
-  ['flaggedProposalTitleKeywords', { action: 'flag', type: 'proposalTitleKeyword' }],
-  ['flaggedProposalBodyKeywords', { action: 'flag', type: 'proposalBodyKeyword' }],
   ['verifiedTokens', { file: 'verifiedTokens.json' }]
 ]);
 

--- a/test/e2e/__snapshots__/moderation.test.ts.snap
+++ b/test/e2e/__snapshots__/moderation.test.ts.snap
@@ -36,14 +36,6 @@ exports[`GET /api/moderation when list params is empty returns all the list 1`] 
     "https://facebook.com",
     "https://gogle.com",
   ],
-  "flaggedProposalBodyKeywords": [
-    "claim drop",
-    "token",
-  ],
-  "flaggedProposalTitleKeywords": [
-    "hello",
-    "test string",
-  ],
   "verifiedTokens": {
     "test": {
       "value": "a",

--- a/test/fixtures/moderation.ts
+++ b/test/fixtures/moderation.ts
@@ -8,14 +8,6 @@ export const SqlFixtures: Record<string, any[]> = {
     { action: 'flag', type: 'address', value: '0x0001', created: 100 },
     { action: 'flag', type: 'address', value: '0x0002', created: 100 }
   ],
-  flaggedProposalTitleKeyword: [
-    { action: 'flag', type: 'proposalTitleKeyword', value: 'hello', created: 100 },
-    { action: 'flag', type: 'proposalTitleKeyword', value: 'test string', created: 100 }
-  ],
-  flaggedProposalBodyKeyword: [
-    { action: 'flag', type: 'proposalBodyKeyword', value: 'claim drop', created: 100 },
-    { action: 'flag', type: 'proposalBodyKeyword', value: 'token', created: 100 }
-  ],
   flaggedIps: [
     {
       action: 'flag',

--- a/test/unit/lib/__snapshots__/moderationList.test.ts.snap
+++ b/test/unit/lib/__snapshots__/moderationList.test.ts.snap
@@ -23,14 +23,6 @@ exports[`moderationList returns all fields by default 1`] = `
     "https://gogle.com",
     "https://facebook.com",
   ],
-  "flaggedProposalBodyKeywords": [
-    "claim drop",
-    "token",
-  ],
-  "flaggedProposalTitleKeywords": [
-    "hello",
-    "test string",
-  ],
   "verifiedTokens": {
     "test": {
       "value": "a",


### PR DESCRIPTION
Removing unused flagged proposals title and body keywords