### PR TITLE
Adding Developer DAO (CODE) Token as verified token

### DIFF
--- a/data/verifiedTokens.json
+++ b/data/verifiedTokens.json
@@ -19,7 +19,7 @@
       "logoURI": ""
     },
     {
-      "name": "Developer DAO CODE",
+      "name": "Developer DAO (CODE)",
       "address": "0xb24cd494faE4C180A89975F1328Eab2a7D5d8f11",
       "symbol": "CODE",
       "decimals": 18,

--- a/data/verifiedTokens.json
+++ b/data/verifiedTokens.json
@@ -17,6 +17,14 @@
       "decimals": 18,
       "chainId": 5,
       "logoURI": ""
+    },
+    {
+      "name": "Developer DAO CODE",
+      "address": "0xb24cd494faE4C180A89975F1328Eab2a7D5d8f11",
+      "symbol": "CODE",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://szugq64bhvqg3dhbeihnnbbvx7peynjusnu2j2nv4jyzcshkqofa.arweave.net/lmhoe4E9YG2M4SIO1oQ1v95MNTSTaaTpteJxkUjqg4o"
     }
   ]
 }


### PR DESCRIPTION
This PR adds CODE as a verified token in snapshot for use with oSnap module as per [the docs](https://docs.snapshot.org/user-guides/token-verification).

Validate token address via token.developerdao.eth or on [etherscan](https://etherscan.io/address/0xb24cd494fae4c180a89975f1328eab2a7d5d8f11).