### PR TITLE
chore: fix tests stucked waiting on wrong url

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,11 +12,11 @@
     "dev": "nodemon src/index.ts -e js,ts",
     "start": "node dist/src/index.js",
     "start:test": "dotenv -e test/.env.test yarn dev",
-    "test": "PORT=3003 start-server-and-test 'yarn start:test' 3003 'dotenv -e test/.env.test jest --runInBand'",
+    "test": "PORT=3003 start-server-and-test 'yarn start:test' http://localhost:3003 'dotenv -e test/.env.test jest --runInBand'",
     "test:unit": "dotenv -e test/.env.test jest test/unit/",
     "test:integration": "dotenv -e test/.env.test jest test/integration/",
-    "test:e2e": "PORT=3003 start-server-and-test 'yarn start:test' 3003 'dotenv -e test/.env.test jest --runInBand --collectCoverage=false test/e2e/'",
-    "test:e2e:update-snapshot": "PORT=3003 start-server-and-test 'yarn start:test' 3003 'dotenv -e test/.env.test jest --runInBand --collectCoverage=false --updateSnapshot test/e2e/'"
+    "test:e2e": "PORT=3003 start-server-and-test 'yarn start:test' http://localhost:3003 'dotenv -e test/.env.test jest --runInBand --collectCoverage=false test/e2e/'",
+    "test:e2e:update-snapshot": "PORT=3003 start-server-and-test 'yarn start:test' http://localhost:3003 'dotenv -e test/.env.test jest --runInBand --collectCoverage=false --updateSnapshot test/e2e/'"
   },
   "eslintConfig": {
     "extends": "@snapshot-labs"

--- a/src/lib/storage/file.ts
+++ b/src/lib/storage/file.ts
@@ -17,6 +17,7 @@ class File implements IStorage {
 
   async set(key: string, value: string | Buffer) {
     try {
+      console.log(this.path(), existsSync(this.path()));
       writeFileSync(this.path(key), value);
       console.log(`[storage:file] File saved to ${this.path(key)}`);
 

--- a/src/lib/storage/file.ts
+++ b/src/lib/storage/file.ts
@@ -17,7 +17,6 @@ class File implements IStorage {
 
   async set(key: string, value: string | Buffer) {
     try {
-      console.log(this.path(), existsSync(this.path()));
       writeFileSync(this.path(key), value);
       console.log(`[storage:file] File saved to ${this.path(key)}`);
 

--- a/test/e2e/votesReport.test.ts
+++ b/test/e2e/votesReport.test.ts
@@ -17,7 +17,11 @@ describe('GET /api/votes/:id', () => {
     const votesReport = new VotesReport(id, storage);
 
     beforeAll(async () => {
-      await votesReport.createCache();
+      try {
+        await votesReport.createCache();
+      } catch (e) {
+        console.error('Error while creating the cache');
+      }
     });
 
     it('returns the cached file', async () => {


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

Tests are stucked on some setup, due to `start-server-and-test` script waiting on wrong url.

Additonally, fix some edge case when test are failing due to non-existing folder on CI

## 💊 Fixes / Solution

Pass the full absolute url instead of just the port to `start-server-and-test`

## 🛠️ Tests

- Run `yarn test`
- Test should run
- Test should pass on CI