### PR TITLE
chore: fix failing tests

### DIFF
--- a/test/e2e/votesReport.test.ts
+++ b/test/e2e/votesReport.test.ts
@@ -1,6 +1,6 @@
 import request from 'supertest';
 import VotesReport from '../../src/lib/votesReport';
-import { storageEngine } from '../../src/helpers/utils';
+import { storageEngine, sleep } from '../../src/helpers/utils';
 import { rmSync } from 'fs';
 
 const HOST = `http://localhost:${process.env.PORT || 3003}`;
@@ -41,6 +41,7 @@ describe('GET /api/votes/:id', () => {
 
         const votesReport = new VotesReport(id, storage);
         expect(typeof (await votesReport.getCache())).not.toBe(false);
+        await sleep(parseInt(process.env.QUEUE_INTERVAL || '15e3'));
       });
     });
 


### PR DESCRIPTION
Fix still failing tests, due to queue doing things async after test have ended.

This PR add a `sleep` to some tests, allowing more time for the queue to complete their task before shutting down the instance