### PR TITLE
fix: fix incorrect parsing of queue interval

### DIFF
--- a/src/lib/queue.ts
+++ b/src/lib/queue.ts
@@ -59,7 +59,7 @@ async function run() {
   } catch (e) {
     capture(e);
   } finally {
-    await sleep(parseInt(process.env.QUEUE_INTERVAL || '15e3'));
+    await sleep(parseInt(process.env.QUEUE_INTERVAL || '15000'));
     await run();
   }
 }


### PR DESCRIPTION
Fix invalid parsing of `15e3`, which ends up as `15` instead of `15000`