### PR TITLE
chore: instrument the cache engine

### DIFF
--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -1,4 +1,5 @@
 import { IStorage } from './storage/types';
+import { cacheHitCount } from './metrics';
 
 export default class Cache {
   id: string;
@@ -17,8 +18,12 @@ export default class Cache {
     return '';
   }
 
-  getCache() {
-    return this.storage.get(this.filename);
+  async getCache() {
+    const cache = await this.storage.get(this.filename);
+
+    cacheHitCount.inc({ status: !cache ? 'MISS' : 'HIT', type: this.constructor.name });
+
+    return cache;
   }
 
   async isCacheable() {

--- a/src/lib/metrics/index.ts
+++ b/src/lib/metrics/index.ts
@@ -157,6 +157,12 @@ try {
   }
 }
 
+export const cacheHitCount = new client.Counter({
+  name: 'cache_hit_count',
+  help: 'Number of hit/miss of the cache engine',
+  labelNames: ['status', 'type']
+});
+
 const providersResponseCode = new client.Gauge({
   name: 'provider_response_code',
   help: 'Response code of each provider request',


### PR DESCRIPTION
## 🚧 Changes

Instrument the cache engine

- Track number of hit/miss per type (votesReports, aiSummary, etc...)

## 🛠️ Tests

- Send a curl request to any endpoint using a cache (e.g. `curl -X POST localhost:3005/api/votes/[PROPOSAL-ID]`)
- Go to http://localhost:3005/metrics
- You should see new metrics under

```
# HELP cache_hit_count Number of hit/miss of the cache engine
# TYPE cache_hit_count counter
```
