### PR TITLE
fix: parseInt won't work with 15e3

### DIFF
--- a/test/e2e/votesReport.test.ts
+++ b/test/e2e/votesReport.test.ts
@@ -41,7 +41,7 @@ describe('GET /api/votes/:id', () => {
 
         const votesReport = new VotesReport(id, storage);
         expect(typeof (await votesReport.getCache())).not.toBe(false);
-        await sleep(parseInt(process.env.QUEUE_INTERVAL || '15e3'));
+        await sleep(parseInt(process.env.QUEUE_INTERVAL || '15000'));
       });
     });
 


### PR DESCRIPTION
`parseInt(process.env.QUEUE_INTERVAL || '15e3')` will be actually `15`

![image](https://github.com/snapshot-labs/snapshot-sidekick/assets/15967809/af790a14-a775-44c4-be13-59f6f470be94)
