### PR TITLE
chore: disable nft claimer tests

### DIFF
--- a/test/e2e/nftClaimer.test.ts
+++ b/test/e2e/nftClaimer.test.ts
@@ -6,7 +6,7 @@ describe('nftClaimer', () => {
   describe('GET /api/nft-claimer', () => {
     jest.retryTimes(3);
 
-    it('returns an object with the snapshotFee', async () => {
+    it.skip('returns an object with the snapshotFee', async () => {
       const response = await request(HOST).get('/api/nft-claimer');
       const fee = response.body.snapshotFee;
 

--- a/test/unit/lib/nftClaimer/deploy.test.ts
+++ b/test/unit/lib/nftClaimer/deploy.test.ts
@@ -68,7 +68,7 @@ describe('nftClaimer', () => {
     }
 
     describe('when deployable', () => {
-      it('generates the same signature as the smart contract from the data', async () => {
+      it.skip('generates the same signature as the smart contract from the data', async () => {
         mockValidateDeployInput.mockReturnValueOnce(input);
 
         const { signature } = await getPayload();
@@ -80,7 +80,7 @@ describe('nftClaimer', () => {
         expect(signature.v).toEqual(expectedScSignature.v);
       });
 
-      it('generates the same initializer as the smart contract from the data', async () => {
+      it.skip('generates the same initializer as the smart contract from the data', async () => {
         mockValidateDeployInput.mockReturnValueOnce(input);
 
         const { initializer } = await getPayload();
@@ -90,7 +90,7 @@ describe('nftClaimer', () => {
         expect(initializer).toEqual(expectedInitializer);
       });
 
-      it('can recover the signer from the digest', async () => {
+      it.skip('can recover the signer from the digest', async () => {
         mockValidateDeployInput.mockReturnValueOnce(input);
 
         const recoveredSigner = recoverAddress(expectedDigest, {
@@ -104,7 +104,7 @@ describe('nftClaimer', () => {
     });
 
     describe('when the space validation failed', () => {
-      it('throws an error', () => {
+      it.skip('throws an error', () => {
         mockValidateSpace.mockImplementation(() => {
           throw new Error();
         });
@@ -114,11 +114,11 @@ describe('nftClaimer', () => {
     });
 
     describe('when passing invalid values', () => {
-      it('throws an error when the spaceOwer address is not valid', () => {
+      it.skip('throws an error when the spaceOwer address is not valid', () => {
         expect(async () => await getPayload({ spaceOwner: 'test' })).rejects.toThrow();
       });
 
-      it('throws an error when the spaceTreasury address is not valid', () => {
+      it.skip('throws an error when the spaceTreasury address is not valid', () => {
         expect(async () => await getPayload({ spaceTreasury: 'test' })).rejects.toThrow();
       });
 
@@ -138,7 +138,7 @@ describe('nftClaimer', () => {
         expect(async () => await getPayload({ proposerFee: val as any })).rejects.toThrow();
       });
 
-      it('throws an error when the proposerFee is out of range', () => {
+      it.skip('throws an error when the proposerFee is out of range', () => {
         expect(async () => await getPayload({ proposerFee: '101' })).rejects.toThrow();
         expect(async () => await getPayload({ proposerFee: '-5' })).rejects.toThrow();
       });

--- a/test/unit/lib/nftClaimer/mint.test.ts
+++ b/test/unit/lib/nftClaimer/mint.test.ts
@@ -84,7 +84,7 @@ describe('nftClaimer', () => {
     }
 
     describe('when mintable', () => {
-      it('generates the same signature as the smart contract from the data', async () => {
+      it.skip('generates the same signature as the smart contract from the data', async () => {
         const { signature } = await getPayload();
 
         expect(mockFetchProposal).toHaveBeenCalledWith(hexProposalId);
@@ -93,7 +93,7 @@ describe('nftClaimer', () => {
         expect(signature.v).toEqual(expectedScSignature.v);
       });
 
-      it('can recover the signer from the digest', async () => {
+      it.skip('can recover the signer from the digest', async () => {
         const recoveredSigner = recoverAddress(expectedDigest, {
           r: expectedScSignature.r,
           s: expectedScSignature.s,
@@ -105,7 +105,7 @@ describe('nftClaimer', () => {
     });
 
     describe('when spaceCollection is not found', () => {
-      it('throws a SpaceCollection not found error', async () => {
+      it.skip('throws a SpaceCollection not found error', async () => {
         mockGetProposalContract.mockImplementationOnce(() => {
           throw new Error();
         });
@@ -114,21 +114,21 @@ describe('nftClaimer', () => {
     });
 
     describe('when space has closed minting', () => {
-      it('throws an error', () => {
+      it.skip('throws an error', () => {
         mockMintingAllowed.mockReturnValueOnce(false);
         return expect(async () => await payload(input)).rejects.toThrow();
       });
     });
 
     describe('when address has not voted on the proposal', () => {
-      it('throws an error', () => {
+      it.skip('throws an error', () => {
         mockHasVoted.mockReturnValueOnce(false);
         return expect(async () => await payload(input)).rejects.toThrow();
       });
     });
 
     describe('when address has already minted', () => {
-      it('throws an error', () => {
+      it.skip('throws an error', () => {
         mockHasMinted.mockReturnValueOnce(true);
         return expect(async () => await payload(input)).rejects.toThrow();
       });
@@ -139,11 +139,11 @@ describe('nftClaimer', () => {
     });
 
     describe('when passing invalid values', () => {
-      it('throws an error when the proposalAuthor address is not valid', () => {
+      it.skip('throws an error when the proposalAuthor address is not valid', () => {
         expect(async () => getPayload({ proposalAuthor: 'test' })).rejects.toThrow();
       });
 
-      it('throws an error when the recipient address is not valid', () => {
+      it.skip('throws an error when the recipient address is not valid', () => {
         expect(
           async () =>
             await getPayload({
@@ -161,7 +161,7 @@ describe('nftClaimer', () => {
         ).rejects.toThrow();
       });
 
-      it('throws an error when the proposal is not found', () => {
+      it.skip('throws an error when the proposal is not found', () => {
         mockFetchProposal.mockReturnValueOnce(null);
         return expect(getPayload()).rejects.toThrow();
       });

--- a/test/unit/lib/nftClaimer/utils.test.ts
+++ b/test/unit/lib/nftClaimer/utils.test.ts
@@ -6,7 +6,7 @@ import {
 
 describe('NFTClaimer/utils', () => {
   describe('validateAddresses()', () => {
-    it('returns true when all addresses are valid', () => {
+    it.skip('returns true when all addresses are valid', () => {
       expect(
         validateAddresses({
           contractA: '0x054a600d8B766c786270E25872236507D8459D8F',
@@ -14,7 +14,7 @@ describe('NFTClaimer/utils', () => {
         })
       ).toBe(true);
     });
-    it('throws an error when some of the addresses are invalid', () => {
+    it.skip('throws an error when some of the addresses are invalid', () => {
       expect(() => {
         validateAddresses({
           contractA: '0x054a600d8B766c786270E25872236507D8459D8F',
@@ -25,7 +25,7 @@ describe('NFTClaimer/utils', () => {
   });
 
   describe('validateProposerFee()', () => {
-    it('throws an error when proposerFee + snapshotFee > 100', () => {
+    it.skip('throws an error when proposerFee + snapshotFee > 100', () => {
       return expect(async () => {
         await validateProposerFee(100);
       }).rejects.toThrow();
@@ -33,7 +33,7 @@ describe('NFTClaimer/utils', () => {
   });
 
   describe('validateProposal()', () => {
-    it('throws an error when the proposalAuthor is not matching', () => {
+    it.skip('throws an error when the proposalAuthor is not matching', () => {
       const address = '0x054a600d8B766c786270E25872236507D8459D8F';
 
       expect(async () => {
@@ -41,7 +41,7 @@ describe('NFTClaimer/utils', () => {
       }).rejects.toThrow();
     });
 
-    it('throws an error when the proposal does not exist', () => {
+    it.skip('throws an error when the proposal does not exist', () => {
       expect(async () => {
         validateProposal(null, '');
       }).rejects.toThrowError('RECORD_NOT_FOUND');


### PR DESCRIPTION
Disable NFT Claimer tests, which were relying on Goerli network, which is now off.