### PR TITLE
fix: cap concurrent queues processing items

### DIFF
--- a/src/lib/queue.ts
+++ b/src/lib/queue.ts
@@ -3,6 +3,7 @@ import { capture } from '@snapshot-labs/snapshot-sentry';
 import Cache from './cache';
 import { timeQueueProcess } from './metrics';
 
+const MAX_CONCURRENT_PROCESSING_ITEMS = 10;
 const queues = new Map<string, Cache>();
 const processingItems = new Map<string, Cache>();
 
@@ -51,6 +52,11 @@ async function run() {
           `[queue] Skip: ${cacheable} is currently being processed, progress:
           ${processingItems.get(id)?.generationProgress}%`
         );
+        return;
+      }
+
+      if (processingItems.size >= MAX_CONCURRENT_PROCESSING_ITEMS) {
+        console.log(`[queue] Skip ${cacheable}: max concurrent processing items reached`);
         return;
       }
 


### PR DESCRIPTION
Bot activities are being detected on the CSV votes endpoint, degrading service performance.

This PR introduces a cap on the number of concurrent CSV votes generation, so that even if 100 different CSV reports are being requested, only 10 are being processed at a given time