### PR TITLE
fix: remove markdown formating from summary

### DIFF
--- a/src/lib/ai/summary.ts
+++ b/src/lib/ai/summary.ts
@@ -33,7 +33,7 @@ class Summary extends Cache {
         messages: [
           {
             role: 'system',
-            content: `The following is a governance proposal of '${space.name}'. Generate me a summary in 350 characters max. Here's the title of the proposal: '${title}'. Here's the content of the proposal: '${body}'.`
+            content: `The following is a governance proposal of '${space.name}'. Generate me a summary in 350 characters max. Here's the title of the proposal: '${title}'. Here's the content of the proposal: '${body}'. Do not repeat the title. Do not format the answer (no markdown, no HTML).`
           }
         ],
         model: 'gpt-4o'


### PR DESCRIPTION
Also instructs AI not to repeat the title.

Closes #288 