### PR TITLE
feat: add domain api to return custom domain associated to an offchain space

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -9,6 +9,7 @@ import { queue, getProgress } from './lib/queue';
 import { snapshotFee } from './lib/nftClaimer/utils';
 import AiSummary from './lib/ai/summary';
 import AiTextToSpeech from './lib/ai/textToSpeech';
+import { getDomain } from './lib/domain';
 
 const router = express.Router();
 
@@ -95,6 +96,17 @@ router.get('/moderation', async (req, res) => {
 
   try {
     res.json(await getModerationList(list ? (list as string).split(',') : undefined));
+  } catch (e) {
+    capture(e);
+    return rpcError(res, 'INTERNAL_ERROR', '');
+  }
+});
+
+router.get('/domains/:domain', async (req, res) => {
+  const { domain } = req.params;
+
+  try {
+    res.json({ domain, space_id: getDomain(domain) });
   } catch (e) {
     capture(e);
     return rpcError(res, 'INTERNAL_ERROR', '');

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { name, version } from '../package.json';
 import { rpcError } from './helpers/utils';
 import initMetrics from './lib/metrics';
 import initCacheRefresher from './lib/cacheRefresher';
+import { initDomainsRefresher } from './lib/domain';
 
 const app = express();
 const PORT = process.env.PORT || 3005;
@@ -18,6 +19,7 @@ const PORT = process.env.PORT || 3005;
 initLogger(app);
 initMetrics(app);
 initCacheRefresher();
+initDomainsRefresher();
 
 app.disable('x-powered-by');
 app.use(express.json({ limit: '4mb' }));

--- a/src/lib/domain.ts
+++ b/src/lib/domain.ts
@@ -1,0 +1,39 @@
+import { capture } from '@snapshot-labs/snapshot-sentry';
+import { sleep } from '../helpers/utils';
+
+const LIST_URL =
+  'https://raw.githubusercontent.com/snapshot-labs/snapshot-spaces/master/spaces/domains.json';
+
+const REFRESH_INTERVAL = 1000 * 60 * 5; // 5 minutes
+
+// Map of domain (vote.snapshot.org) to space ID (s:snapshot.eth/eth:0x0)
+let data = new Map<string, string>();
+
+export function getDomain(domain: string): string | null {
+  return data.get(domain.toLowerCase()) ?? null;
+}
+
+export async function initDomainsRefresher() {
+  try {
+    console.log(`[domains-refresh] Refreshing domains list`);
+    await refreshList();
+    console.log(`[domains-refresh] ${data.size} domains found`);
+  } catch (e) {
+    capture(e);
+  } finally {
+    await sleep(REFRESH_INTERVAL);
+    await initDomainsRefresher();
+  }
+}
+
+async function refreshList() {
+  const response = await fetch(LIST_URL, {
+    headers: {
+      'content-type': 'application/json'
+    }
+  });
+
+  const body: Record<string, string> = await response.json();
+
+  data = new Map(Object.entries(body).map(([domain, spaceId]) => [domain, `s:${spaceId}`]));
+}


### PR DESCRIPTION
Working towards https://github.com/snapshot-labs/workflow/issues/142

See also https://discord.com/channels/955773041898573854/1282876175642918964/1283367668648382587

This PR will add a new `/api/domain` endpoint to return a custom domain associated to an offchain space.

Domains list will be pulled from the snapshot-spaces repo, be cached in memory, and refreshed every 5 minutes.

### Test

- `yarn dev`
- monitor console to confirm that the domain list has been loaded
- `curl http://localhost:3005/api/domains/vote.lends.so`
- it should return `{"domain":"vote.lends.so","space_id":"s:lendsdao.eth"}`
- `curl http://localhost:3005/api/domains/random`
- it should return `{"domain":"vote.lends.so","space_id":null}`