### PR TITLE
fix: stop logging proxy errors

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -160,7 +160,6 @@ router.get('/proxy/:url', async (req, res) => {
 
     return res.json(await response.json());
   } catch (e: any) {
-    capture(e);
     res.status(500).json({
       error: {
         code: 500,


### PR DESCRIPTION
This PR will remove the error logging for the proxy action

Proxy url can be anything, and is raising too much errors