### PR TITLE
fix: monitor only premium networks

### DIFF
--- a/src/helpers/snapshot.ts
+++ b/src/helpers/snapshot.ts
@@ -31,6 +31,11 @@ export type Space = {
   name: string;
 };
 
+export type Network = {
+  id: string;
+  premium: boolean;
+};
+
 const httpLink = createHttpLink({
   uri: `${process.env.HUB_URL || 'https://hub.snapshot.org'}/graphql`,
   fetch: fetchWithKeepAlive
@@ -129,6 +134,15 @@ const SPACE_QUERY = gql`
   }
 `;
 
+const NETWORKS_QUERY = gql`
+  query networks {
+    networks {
+      id
+      premium
+    }
+  }
+`;
+
 export async function fetchProposal(id: string) {
   const {
     data: { proposal }
@@ -188,4 +202,14 @@ export async function fetchSpace(id: string) {
   });
 
   return space;
+}
+
+export async function fetchNetworks() {
+  const {
+    data: { networks }
+  }: { data: { networks: Network[] } } = await client.query({
+    query: NETWORKS_QUERY
+  });
+
+  return networks;
 }


### PR DESCRIPTION
This PR will monitor only premium networks, instead of full list

most non-premium networks are not maintained properly, and are creating a lot of errors that will not be fixed, and consuming all the sentry quota

### How to test

- Go to http://localhost:3005/metrics
- After a while, the list with `provider_response_code` should only contain premium networks