### PR TITLE
fix: reason csv injection

### DIFF
--- a/src/lib/votesReport.ts
+++ b/src/lib/votesReport.ts
@@ -106,7 +106,7 @@ class VotesReport extends Cache {
       vote.vp,
       vote.created,
       vote.ipfs,
-      `"${vote.reason.replace(/(\r\n|\n|\r)/gm, '')}"`
+      `"'${vote.reason.replace(/(\r\n|\n|\r)/gm, '').replace(/"/g, '""')}"`
     ]
       .flat()
       .join(',');


### PR DESCRIPTION
Fixes CSV Injection in the user provided `reason` field of the votes report export.

Sanitization applied based on OWASP guidelines ([https://owasp.org/www-community/attacks/CSV_Injection](https://owasp.org/www-community/attacks/CSV_Injection)):
1.  **Prepends a single quote (`'`)**: Added inside the wrapping double quotes (`"'...`) to force text interpretation by spreadsheet software, preventing formula execution.
2.  **Escapes internal double quotes (`""`)**: Replaces any `"` within the reason with `""`. This is crucial because the entire field is wrapped in double quotes (`"..."`) for CSV formatting. Without escaping, an internal `"` could prematurely terminate the field, causing subsequent content to spill into the next cell. This spilled content would lack the protective leading single quote (`'`), reintroducing the injection vulnerability if it starts with `=`, `+`, `-`, or `@`.

Full bug report:
https://www.notion.so/Snapshot-Vote-Reason-CSV-Injection-1e46b6f7965b80138ed0cbcda842b6e5?pvs=4