### PR TITLE
ci: update ubuntu version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       DATABASE_URL: 'mysql://root:root@127.0.0.1:3306/sidekick_test'
     steps:


### PR DESCRIPTION
Update ubuntu version for since 20.04 has been removed

https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/